### PR TITLE
Fix gazebo include paths

### DIFF
--- a/sr_gazebo_plugins/include/sr_gazebo_plugins/gazebo_ros_controller_manager.h
+++ b/sr_gazebo_plugins/include/sr_gazebo_plugins/gazebo_ros_controller_manager.h
@@ -33,11 +33,11 @@
 #include <vector>
 #include <map>
 
-#include "physics/World.hh"
-#include "physics/Model.hh"
-#include "physics/physics.hh"
-#include "common/Time.hh"
-#include "common/Plugin.hh"
+#include <gazebo/physics/World.hh>
+#include <gazebo/physics/Model.hh>
+#include <gazebo/physics/physics.hh>
+#include <gazebo/common/Time.hh>
+#include <gazebo/common/Plugin.hh>
 
 #include "pr2_hardware_interface/hardware_interface.h"
 #include "pr2_controller_manager/controller_manager.h"

--- a/sr_gazebo_plugins/src/gazebo_ros_controller_manager.cpp
+++ b/sr_gazebo_plugins/src/gazebo_ros_controller_manager.cpp
@@ -36,15 +36,15 @@
 
 //#include <gazebo/XMLConfig.hh>
 //#include "physics/physics.h"
-#include "physics/World.hh"
-#include "physics/HingeJoint.hh"
-#include "sensors/Sensor.hh"
-#include "sdf/sdf.hh"
-#include "sdf/Param.hh"
-#include "common/Exception.hh"
-#include "physics/PhysicsTypes.hh"
-#include "physics/Base.hh"
+#include <gazebo/physics/World.hh>
+#include <gazebo/physics/HingeJoint.hh>
+#include <gazebo/sensors/Sensor.hh>
+#include <gazebo/common/Exception.hh>
+#include <gazebo/physics/PhysicsTypes.hh>
+#include <gazebo/physics/Base.hh>
 
+#include <sdf/sdf.hh>
+#include <sdf/Param.hh>
 
 #include <angles/angles.h>
 #include <urdf/model.h>


### PR DESCRIPTION
This is needed to be compatible with newer Gazebo ABI/API. It is also compatible with Gazebo 1.9, which is the current version in Ubuntu.

This along with https://github.com/shadow-robot/sr-ros-interface/pull/119 is blocking all builds on Fedora, which uses Gazebo 2.2.
