### PR TITLE
Modified collision model (for OMPL to work)

### DIFF
--- a/sr_description/hand/model/F1.dae
+++ b/sr_description/hand/model/F1.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:16:01.949584</created>
 		<modified>2012-07-23T02:16:01.949597</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="black_spec-fx" name="black_spec-fx">

--- a/sr_description/hand/model/F2.dae
+++ b/sr_description/hand/model/F2.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:15:44.246463</created>
 		<modified>2012-07-23T02:15:44.246477</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="black_spec-fx" name="black_spec-fx">

--- a/sr_description/hand/model/F3.dae
+++ b/sr_description/hand/model/F3.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:15:31.855069</created>
 		<modified>2012-07-23T02:15:31.855082</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="black_spec-fx" name="black_spec-fx">

--- a/sr_description/hand/model/TH1_z.dae
+++ b/sr_description/hand/model/TH1_z.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:13:47.090860</created>
 		<modified>2012-07-23T02:13:47.090873</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="black_spec-fx" name="black_spec-fx">

--- a/sr_description/hand/model/TH2_z.dae
+++ b/sr_description/hand/model/TH2_z.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:14:04.601049</created>
 		<modified>2012-07-23T02:14:04.601062</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="black_spec-fx" name="black_spec-fx">

--- a/sr_description/hand/model/TH3_z.dae
+++ b/sr_description/hand/model/TH3_z.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:14:18.666034</created>
 		<modified>2012-07-23T02:14:18.666047</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="black_spec-fx" name="black_spec-fx">

--- a/sr_description/hand/model/biotacs/biotac_decimated.dae
+++ b/sr_description/hand/model/biotacs/biotac_decimated.dae
@@ -8,7 +8,7 @@
     <created>2012-12-14T09:15:39</created>
     <modified>2012-12-14T09:15:39</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
+    <up_axis>Y_UP</up_axis>
   </asset>
   <library_cameras>
     <camera id="Camera-camera" name="Camera">

--- a/sr_description/hand/model/biotacs/biotac_thumb_adapter.dae
+++ b/sr_description/hand/model/biotacs/biotac_thumb_adapter.dae
@@ -8,7 +8,7 @@
     <created>2012-12-14T09:32:52</created>
     <modified>2012-12-14T09:32:52</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
+    <up_axis>Y_UP</up_axis>
   </asset>
   <library_cameras>
     <camera id="Camera-camera" name="Camera">

--- a/sr_description/hand/model/distal_ellipsoid.dae
+++ b/sr_description/hand/model/distal_ellipsoid.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T01:48:41.413018</created>
 		<modified>2012-07-23T01:48:41.413036</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_geometries>
 		<geometry id="ellipsoid-Geometry" name="ellipsoid-Geometry">

--- a/sr_description/hand/model/envelop_light/F1.dae
+++ b/sr_description/hand/model/envelop_light/F1.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:18:18.630014</created>
 		<modified>2012-07-23T02:18:18.630028</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="black_spec-fx" name="black_spec-fx">

--- a/sr_description/hand/model/envelop_light/F2.dae
+++ b/sr_description/hand/model/envelop_light/F2.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:18:03.236589</created>
 		<modified>2012-07-23T02:18:03.236602</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="black_spec-fx" name="black_spec-fx">

--- a/sr_description/hand/model/envelop_light/F3.dae
+++ b/sr_description/hand/model/envelop_light/F3.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:17:30.699549</created>
 		<modified>2012-07-23T02:17:30.699562</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="black_spec-fx" name="black_spec-fx">

--- a/sr_description/hand/model/envelop_light/TH1_z.dae
+++ b/sr_description/hand/model/envelop_light/TH1_z.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:19:57.817591</created>
 		<modified>2012-07-23T02:19:57.817614</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="black_spec-fx" name="black_spec-fx">

--- a/sr_description/hand/model/envelop_light/TH2_z.dae
+++ b/sr_description/hand/model/envelop_light/TH2_z.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:19:43.659883</created>
 		<modified>2012-07-23T02:19:43.659896</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="black_spec-fx" name="black_spec-fx">

--- a/sr_description/hand/model/envelop_light/TH3_z.dae
+++ b/sr_description/hand/model/envelop_light/TH3_z.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:19:26.873500</created>
 		<modified>2012-07-23T02:19:26.873524</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="black_spec-fx" name="black_spec-fx">

--- a/sr_description/hand/model/envelop_light/forearm.dae
+++ b/sr_description/hand/model/envelop_light/forearm.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-09T16:31:07.703152</created>
 		<modified>2012-07-09T16:31:07.703174</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="Material-fx" name="Material-fx">

--- a/sr_description/hand/model/envelop_light/knuckle.dae
+++ b/sr_description/hand/model/envelop_light/knuckle.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:18:42.789987</created>
 		<modified>2012-07-23T02:18:42.790010</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="osg2mat0-fx" name="osg2mat0-fx">

--- a/sr_description/hand/model/envelop_light/lfmetacarpal.dae
+++ b/sr_description/hand/model/envelop_light/lfmetacarpal.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:19:08.920629</created>
 		<modified>2012-07-23T02:19:08.920641</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="black_spec-fx" name="black_spec-fx">

--- a/sr_description/hand/model/envelop_light/palm.dae
+++ b/sr_description/hand/model/envelop_light/palm.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:20:16.267352</created>
 		<modified>2012-07-23T02:20:16.267365</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="black_spec-fx" name="black_spec-fx">

--- a/sr_description/hand/model/envelop_light/wrist.dae
+++ b/sr_description/hand/model/envelop_light/wrist.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:20:30.787713</created>
 		<modified>2012-07-23T02:20:30.787736</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="osg2mat0-fx" name="osg2mat0-fx">

--- a/sr_description/hand/model/envelop_standard/F1.dae
+++ b/sr_description/hand/model/envelop_standard/F1.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:16:01.949584</created>
 		<modified>2012-07-23T02:16:01.949597</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="black_spec-fx" name="black_spec-fx">

--- a/sr_description/hand/model/envelop_standard/F2.dae
+++ b/sr_description/hand/model/envelop_standard/F2.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:15:44.246463</created>
 		<modified>2012-07-23T02:15:44.246477</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="black_spec-fx" name="black_spec-fx">

--- a/sr_description/hand/model/envelop_standard/F3.dae
+++ b/sr_description/hand/model/envelop_standard/F3.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:15:31.855069</created>
 		<modified>2012-07-23T02:15:31.855082</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="black_spec-fx" name="black_spec-fx">

--- a/sr_description/hand/model/envelop_standard/TH1_z.dae
+++ b/sr_description/hand/model/envelop_standard/TH1_z.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:13:47.090860</created>
 		<modified>2012-07-23T02:13:47.090873</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="black_spec-fx" name="black_spec-fx">

--- a/sr_description/hand/model/envelop_standard/TH2_z.dae
+++ b/sr_description/hand/model/envelop_standard/TH2_z.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:14:04.601049</created>
 		<modified>2012-07-23T02:14:04.601062</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="black_spec-fx" name="black_spec-fx">

--- a/sr_description/hand/model/envelop_standard/TH3_z.dae
+++ b/sr_description/hand/model/envelop_standard/TH3_z.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:14:18.666034</created>
 		<modified>2012-07-23T02:14:18.666047</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="black_spec-fx" name="black_spec-fx">

--- a/sr_description/hand/model/envelop_standard/forearm.dae
+++ b/sr_description/hand/model/envelop_standard/forearm.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-09T16:29:53.272413</created>
 		<modified>2012-07-09T16:29:53.272436</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="Material-fx" name="Material-fx">

--- a/sr_description/hand/model/envelop_standard/knuckle.dae
+++ b/sr_description/hand/model/envelop_standard/knuckle.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:15:15.508647</created>
 		<modified>2012-07-23T02:15:15.508662</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="osg2mat0-fx" name="osg2mat0-fx">

--- a/sr_description/hand/model/envelop_standard/lfmetacarpal.dae
+++ b/sr_description/hand/model/envelop_standard/lfmetacarpal.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:16:22.697136</created>
 		<modified>2012-07-23T02:16:22.697149</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="black_spec-fx" name="black_spec-fx">

--- a/sr_description/hand/model/envelop_standard/palm.dae
+++ b/sr_description/hand/model/envelop_standard/palm.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:03:42.155704</created>
 		<modified>2012-07-23T02:03:42.155716</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="black_spec-fx" name="black_spec-fx">

--- a/sr_description/hand/model/envelop_standard/wrist.dae
+++ b/sr_description/hand/model/envelop_standard/wrist.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:14:55.555034</created>
 		<modified>2012-07-23T02:14:55.555052</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="osg2mat0-fx" name="osg2mat0-fx">

--- a/sr_description/hand/model/forearm.dae
+++ b/sr_description/hand/model/forearm.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-09T16:29:53.272413</created>
 		<modified>2012-07-09T16:29:53.272436</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="Material-fx" name="Material-fx">

--- a/sr_description/hand/model/forearm_muscle.dae
+++ b/sr_description/hand/model/forearm_muscle.dae
@@ -8,7 +8,7 @@
     <created>2013-02-21T11:19:02</created>
     <modified>2013-02-21T11:19:02</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
+    <up_axis>Y_UP</up_axis>
   </asset>
 	<library_effects>
 		<effect id="black_spec-fx" name="black_spec-fx">

--- a/sr_description/hand/model/forearm_muscle_disk.dae
+++ b/sr_description/hand/model/forearm_muscle_disk.dae
@@ -8,7 +8,7 @@
     <created>2013-02-21T11:51:39</created>
     <modified>2013-02-21T11:51:39</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
+    <up_axis>Y_UP</up_axis>
   </asset>
 	<library_effects>
 		<effect id="black_spec-fx" name="black_spec-fx">

--- a/sr_description/hand/model/knuckle.dae
+++ b/sr_description/hand/model/knuckle.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:15:15.508647</created>
 		<modified>2012-07-23T02:15:15.508662</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="osg2mat0-fx" name="osg2mat0-fx">

--- a/sr_description/hand/model/lfmetacarpal.dae
+++ b/sr_description/hand/model/lfmetacarpal.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:16:22.697136</created>
 		<modified>2012-07-23T02:16:22.697149</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="black_spec-fx" name="black_spec-fx">

--- a/sr_description/hand/model/palm.dae
+++ b/sr_description/hand/model/palm.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:03:42.155704</created>
 		<modified>2012-07-23T02:03:42.155716</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="black_spec-fx" name="black_spec-fx">

--- a/sr_description/hand/model/wrist.dae
+++ b/sr_description/hand/model/wrist.dae
@@ -11,7 +11,7 @@
 		<created>2012-07-23T02:14:55.555034</created>
 		<modified>2012-07-23T02:14:55.555052</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
+		<up_axis>Y_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="osg2mat0-fx" name="osg2mat0-fx">

--- a/sr_description/hand/xacro/finger/knuckle/edc_muscle_knuckle.urdf.xacro
+++ b/sr_description/hand/xacro/finger/knuckle/edc_muscle_knuckle.urdf.xacro
@@ -26,9 +26,9 @@
       <material name="LightGrey" />
       </visual>
       <collision>
-	<origin xyz="0 0 0" rpy="0 0 0" />
+	<origin xyz="0 0 0" rpy="0 1.5708 0" />
 	<geometry name="${link_prefix}knuckle_collision_geom">
-	  <box size="0.005 0.005 0.005" />
+	  <cylinder radius="0.007" length="0.014" />
 	</geometry>
       </collision>
     </link>

--- a/sr_description/hand/xacro/finger/knuckle/knuckle.urdf.xacro
+++ b/sr_description/hand/xacro/finger/knuckle/knuckle.urdf.xacro
@@ -26,9 +26,9 @@
       <material name="LightGrey" />
       </visual>
       <collision>
-	<origin xyz="0 0 0" rpy="0 0 0" />
+	<origin xyz="0 0 0" rpy="0 1.5708 0" />
 	<geometry name="${link_prefix}knuckle_collision_geom">
-	  <box size="0.005 0.005 0.005" />
+	  <cylinder radius="0.007" length="0.014" />
 	</geometry>
       </collision>
     </link>

--- a/sr_description/hand/xacro/finger/lfmetacarpal/edc_muscle_lfmetacarpal.urdf.xacro
+++ b/sr_description/hand/xacro/finger/lfmetacarpal/edc_muscle_lfmetacarpal.urdf.xacro
@@ -36,7 +36,7 @@
         <material name="Grey" />
       </visual>
       <collision>
-        <origin xyz="0 0 0.042" rpy="0 0 0" />
+        <origin xyz="0 0 0.038" rpy="0 0 0" />
         <geometry name="lfmetacarpal_collision_geom">
           <box size="0.018 0.024 0.048" />
         </geometry>
@@ -57,6 +57,7 @@
 	  <bumperTopicName>contacts/lf/metacarpal</bumperTopicName>
         </plugin>
       </sensor>
+      <selfCollide>true</selfCollide>
       <material>LightGrey</material>
     </gazebo>
 

--- a/sr_description/hand/xacro/finger/lfmetacarpal/edc_muscle_lfmetacarpal.urdf.xacro
+++ b/sr_description/hand/xacro/finger/lfmetacarpal/edc_muscle_lfmetacarpal.urdf.xacro
@@ -36,9 +36,9 @@
         <material name="Grey" />
       </visual>
       <collision>
-          <origin xyz="0 0 0.04" rpy="0 0 0" />
+        <origin xyz="0 0 0.042" rpy="0 0 0" />
         <geometry name="lfmetacarpal_collision_geom">
-          <box size="0.008 0.008 0.03" />
+          <box size="0.018 0.024 0.048" />
         </geometry>
       </collision>
     </link>

--- a/sr_description/hand/xacro/finger/lfmetacarpal/lfmetacarpal.urdf.xacro
+++ b/sr_description/hand/xacro/finger/lfmetacarpal/lfmetacarpal.urdf.xacro
@@ -36,9 +36,9 @@
         <material name="Grey" />
       </visual>
       <collision>
-        <origin xyz="0 0 0.042" rpy="0 0 0" />
+        <origin xyz="0 0 0.038" rpy="0 0 0" />
         <geometry name="lfmetacarpal_collision_geom">
-          <box size="0.018 0.024 0.048" />
+          <box size="0.018 0.024 0.040" />
         </geometry>
       </collision>
     </link>
@@ -57,6 +57,7 @@
 	  <bumperTopicName>contacts/lf/metacarpal</bumperTopicName>
         </plugin>
       </sensor>
+      <selfCollide>true</selfCollide>
       <material>LightGrey</material>
     </gazebo>
 

--- a/sr_description/hand/xacro/finger/lfmetacarpal/lfmetacarpal.urdf.xacro
+++ b/sr_description/hand/xacro/finger/lfmetacarpal/lfmetacarpal.urdf.xacro
@@ -36,9 +36,9 @@
         <material name="Grey" />
       </visual>
       <collision>
-          <origin xyz="0 0 0.04" rpy="0 0 0" />
+        <origin xyz="0 0 0.042" rpy="0 0 0" />
         <geometry name="lfmetacarpal_collision_geom">
-          <box size="0.008 0.008 0.03" />
+          <box size="0.018 0.024 0.048" />
         </geometry>
       </collision>
     </link>

--- a/sr_description/hand/xacro/finger/middle/middle.urdf.xacro
+++ b/sr_description/hand/xacro/finger/middle/middle.urdf.xacro
@@ -24,11 +24,23 @@
       </geometry>
       <material name="Grey" />
       </visual>
+    <collision>
+        <origin xyz="0 0 0.0125" rpy="0 0 0 " />
+        <geometry name="${link_prefix}middle_collision_geom">
+          <cylinder radius="0.007" length="0.025" />
+        </geometry>
+      </collision>
       <collision>
-	<origin xyz="0 0 0.0125" rpy="0 0 0" />
-	<geometry name="${link_prefix}middle_collision_geom">
-	  <box size="0.008 0.008 0.015" />
-	</geometry>
+        <origin xyz="0 0 0.0" rpy="0 0 0 " />
+        <geometry>
+          <sphere radius="0.007" />
+        </geometry>
+      </collision>
+      <collision>
+        <origin xyz="0 0 0.025" rpy="0 0 0 " />
+        <geometry>
+          <sphere radius="0.007" />
+        </geometry>
       </collision>
     </link>
 
@@ -46,6 +58,7 @@
 	  <bumperTopicName>contacts/${link_prefix}/middle</bumperTopicName>
         </plugin>
       </sensor>
+       <selfCollide>true</selfCollide>
       <material>LightGrey</material>
     </gazebo>
 

--- a/sr_description/hand/xacro/finger/proximal/edc_muscle_proximal.urdf.xacro
+++ b/sr_description/hand/xacro/finger/proximal/edc_muscle_proximal.urdf.xacro
@@ -25,10 +25,10 @@
       <material name="Grey" />
       </visual>
       <collision>
-	<origin xyz="0 0 0.025" rpy="0 0 0 " />
-	<geometry name="proximal_collision_geom">
-	  <box size="0.008 0.008 0.04" />
-	</geometry>
+        <origin xyz="0 0 0.025" rpy="0 0 0 " />
+        <geometry name="${link_prefix}proximal_collision_geom">
+          <cylinder radius="0.007" length="0.040" />
+        </geometry>
       </collision>
     </link>
 
@@ -46,6 +46,7 @@
 	  <bumperTopicName>contacts/${link_prefix}/proximal</bumperTopicName>
         </plugin>
       </sensor>
+      <selfCollide>true</selfCollide>
       <material>LightGrey</material>
     </gazebo>
 

--- a/sr_description/hand/xacro/finger/proximal/proximal.urdf.xacro
+++ b/sr_description/hand/xacro/finger/proximal/proximal.urdf.xacro
@@ -12,23 +12,23 @@
 
     <link name="${link_prefix}proximal">
       <inertial>
-	<mass value="0.014" />
-	<origin xyz="0 0 0.0225" />
-	<inertia  ixx="0.1" ixy="0.0"  ixz="0.0"  iyy="0.1"  iyz="0.0"
-	izz="0.0" />
+        <mass value="0.014" />
+        <origin xyz="0 0 0.0225" />
+        <inertia  ixx="0.1" ixy="0.0"  ixz="0.0"  iyy="0.1"  iyz="0.0"
+        izz="0.0" />
       </inertial>
       <visual>
-	<origin xyz="0 0 0" rpy="0 0 0" />
-	<geometry name="proximal_visual">
-      <mesh filename="package://sr_description/hand/model/F3.dae" scale="0.001 0.001 0.001" />
-      </geometry>
-      <material name="Grey" />
+      <origin xyz="0 0 0" rpy="0 0 0" />
+        <geometry name="${link_prefix}proximal_visual">
+          <mesh filename="package://sr_description/hand/model/F3.dae" scale="0.001 0.001 0.001" />
+        </geometry>
+        <material name="Grey" />
       </visual>
       <collision>
-	<origin xyz="0 0 0.025" rpy="0 0 0 " />
-	<geometry name="proximal_collision_geom">
-	  <box size="0.008 0.008 0.04" />
-	</geometry>
+        <origin xyz="0 0 0.025" rpy="0 0 0 " />
+        <geometry name="${link_prefix}proximal_collision_geom">
+          <cylinder radius="0.007" length="0.040" />
+        </geometry>
       </collision>
     </link>
 
@@ -46,6 +46,7 @@
 	  <bumperTopicName>contacts/${link_prefix}/proximal</bumperTopicName>
         </plugin>
       </sensor>
+       <selfCollide>true</selfCollide>
       <material>LightGrey</material>
     </gazebo>
 

--- a/sr_description/hand/xacro/palm/edc_muscle_palm.urdf.xacro
+++ b/sr_description/hand/xacro/palm/edc_muscle_palm.urdf.xacro
@@ -35,12 +35,24 @@
 	</geometry>
 	<material name="Grey"/>
       </visual>
-      <collision>
-	<origin xyz="0.005 0 0.035" rpy="0 0 0" />
+        <collision>
+	<origin xyz="0.011 0 0.038" rpy="0 0 0" />
 	<geometry name="palm_collision_geom">
-	  <box size="0.05 0.02 0.07" />
+	  <box size="0.062 0.024 0.098" />
 	</geometry>
-      </collision>
+    </collision>
+    <collision>
+      <origin xyz="0.011 0 0.089" rpy="0 0 0" />
+	    <geometry>
+        <box size="0.018 0.024 0.004" />
+      </geometry>
+    </collision> 
+    <collision>
+      <origin xyz="-0.030 0 0.009" rpy="0 0 0" />
+	    <geometry>
+        <box size="0.020 0.024 0.040" />
+      </geometry>
+    </collision> 
     </link>
 
     <gazebo reference="palm">

--- a/sr_description/hand/xacro/palm/palm.urdf.xacro
+++ b/sr_description/hand/xacro/palm/palm.urdf.xacro
@@ -36,11 +36,23 @@
 	<material name="Grey"/>
       </visual>
       <collision>
-	<origin xyz="0.005 0 0.035" rpy="0 0 0" />
+	<origin xyz="0.011 0 0.038" rpy="0 0 0" />
 	<geometry name="palm_collision_geom">
-	  <box size="0.05 0.02 0.07" />
+	  <box size="0.062 0.024 0.098" />
 	</geometry>
-      </collision>
+    </collision>
+    <collision>
+      <origin xyz="0.011 0 0.089" rpy="0 0 0" />
+	    <geometry>
+        <box size="0.018 0.024 0.004" />
+      </geometry>
+    </collision> 
+    <collision>
+      <origin xyz="-0.030 0 0.009" rpy="0 0 0" />
+	    <geometry>
+        <box size="0.020 0.024 0.040" />
+      </geometry>
+    </collision> 
     </link>
 
     <gazebo reference="palm">

--- a/sr_description/hand/xacro/thumb/thbase.urdf.xacro
+++ b/sr_description/hand/xacro/thumb/thbase.urdf.xacro
@@ -37,12 +37,12 @@
       <material name="shadow_thbase_material">
 	  <color rgba="0.5 0.5 0.5 1.0"/>
 	</material>
-      </visual>
-      <collision>
-	<origin xyz="0 0 0" rpy="0 0 0 " />
+      </visual> 
+       <collision>
+        <origin xyz="0 0 0.0" rpy="0 0 0 " />
 	<geometry name="thbase_collision_geom">
-	  <box size="0.001 0.001 0.001" />
-	</geometry>
+          <sphere radius="0.011" />
+        </geometry>
       </collision>
     </link>
 
@@ -60,6 +60,7 @@
 	  <bumperTopicName>contacts/th/base</bumperTopicName>
         </plugin>
       </sensor>
+       <selfCollide>false</selfCollide>
       <material>LightGrey</material>
     </gazebo>
 

--- a/sr_description/hand/xacro/thumb/thhub.urdf.xacro
+++ b/sr_description/hand/xacro/thumb/thhub.urdf.xacro
@@ -26,11 +26,11 @@
 	  <color rgba="0.7 0.7 0.7 1.0"/>
 	</material>
       </visual>
-      <collision>
-	<origin xyz="0 0 0" rpy="0 0 0 " />
-	<geometry name="thhub_collision_geom">
-	  <box size="0.001 0.001 0.001" />
-	</geometry>
+            <collision>
+        <origin xyz="0 0 0.0" rpy="0 0 0 " />
+       <geometry name="thhub_collision_geom">
+          <sphere radius="0.010" />
+        </geometry>
       </collision>
     </link>
 
@@ -48,6 +48,7 @@
 	  <bumperTopicName>contacts/th/hub</bumperTopicName>
         </plugin>
       </sensor>
+       <selfCollide>true</selfCollide>
       <material>LightGrey</material>
     </gazebo>
 

--- a/sr_description/hand/xacro/thumb/thmiddle.urdf.xacro
+++ b/sr_description/hand/xacro/thumb/thmiddle.urdf.xacro
@@ -26,12 +26,20 @@
 	  <color rgba="0.2 0.2 0.2 1.0"/>
 	</material>
       </visual>
+     
       <collision>
-	<origin xyz="0 0 0.016" rpy="0 0 0 " />
-	<geometry name="thmiddle_collision_geom">
-	  <box size="0.008 0.008 0.015" />
-	</geometry>
+        <origin xyz="0 0 0.016" rpy="0 0 0 " />
+        <geometry name="thmiddle_collision_geom">
+          <cylinder radius="0.011" length="0.031" />
+        </geometry>
       </collision>
+      <collision>
+        <origin xyz="0 0 0.032" rpy="0 0 0 " />
+        <geometry>
+          <sphere radius="0.010" />
+        </geometry>
+      </collision> 
+      
     </link>
 
     <gazebo reference="thmiddle">
@@ -47,7 +55,8 @@
 	  <frameName>thmiddle</frameName>
 	  <bumperTopicName>contacts/th/middle</bumperTopicName>
         </plugin>
-      </sensor>
+      </sensor> 
+      <selfCollide>true</selfCollide>
       <material>LightGrey</material>
     </gazebo>
 

--- a/sr_description/hand/xacro/thumb/thproximal.urdf.xacro
+++ b/sr_description/hand/xacro/thumb/thproximal.urdf.xacro
@@ -36,13 +36,13 @@
       <material name="shadow_thproximal_material">
 	  <color rgba="0.2 0.2 0.2 1.0"/>
 	</material>
-      </visual>
-      <collision>
-	<origin xyz="0 0 0.019" rpy="0 0 0" />
-	<geometry name="thproximal_collision_geom">
-	  <box size="0.008 0.008 0.020" />
-	</geometry>
-      </collision>
+      </visual>   
+       <collision>
+        <origin xyz="0 0 0.020" rpy="0 0 0 " />
+        <geometry name="thproximal_collision_geom">
+          <cylinder radius="0.012" length="0.018" />
+        </geometry>
+      </collision>      
     </link>
 
     <gazebo reference="thproximal">
@@ -59,6 +59,7 @@
 	  <bumperTopicName>contacts/th/proximal</bumperTopicName>
         </plugin>
       </sensor>
+       <selfCollide>false</selfCollide>
       <material>LightGrey</material>
     </gazebo>
 

--- a/sr_description/hand/xacro/wrist/wrist.urdf.xacro
+++ b/sr_description/hand/xacro/wrist/wrist.urdf.xacro
@@ -35,11 +35,35 @@
 	<material name="LightGrey" />
       </visual>
       <collision>
-	<origin xyz="0 0 0" rpy="0 0 0" />
+	<origin xyz="0 0 0" rpy="1.5708 1.5708 0 " />
 	<geometry name="wrist_collision_geom">
-	  <box size="0.02 0.02 0.02" />
+	  <cylinder radius="0.0135" length="0.030" />
 	</geometry>
       </collision>
+      <collision>
+	<origin xyz="-0.026 0 0.034" rpy="0 1.5708 0" />
+	<geometry>
+	 <cylinder radius="0.011" length="0.010" />
+	</geometry>
+      </collision>
+      <collision>
+	<origin xyz="0.031 0 0.034" rpy="0 1.5708 0" />
+	<geometry>
+	 <cylinder radius="0.011" length="0.010" />
+	</geometry>
+      </collision>
+       <collision>
+	<origin xyz="-0.021 0 0.011" rpy="0 0.7854 0" />
+	<geometry>
+	  <box size="0.027 0.018 0.010" />
+	</geometry>
+      </collision>
+      <collision>
+	<origin xyz="0.026 0 0.010" rpy="0 -0.7854 0" />
+	<geometry>
+	  <box size="0.027 0.018 0.010" />
+	</geometry>
+      </collision> 
     </link>
     <gazebo reference="wrist">
       <material>PR2/Grey2</material>


### PR DESCRIPTION
Collision model changed to avoid bad OMPL planning (spaces between links permit fingers to pass through each other)
Collision dae files with Y_UP to get OMPL compute collision correctly ( https://github.com/ros-planning/moveit_ros/issues/316 ) => Does not affect rviz nor gazebo display and gazebo contacts still work perfectly.
Primitive collision model now with multiple collision objects (now handled in hydro) such as cylinders and spheres to create capsules. Checked for no self collision between links close together through hub links (proximal/palm, thmiddle/thproximal). Adjacent links are disabled in gazebo by default anyway.
Enabled self_collision not to permit crossed fingers in gazebo
