### PR TITLE
Changed inertia and force limits for biotac fingertip

### DIFF
--- a/sr_description/hand/xacro/finger/biotac/biotac.urdf.xacro
+++ b/sr_description/hand/xacro/finger/biotac/biotac.urdf.xacro
@@ -19,7 +19,8 @@
       <inertial>
         <origin xyz="0 0 0.0125" rpy="0 0 0" />
         <mass value="0.012" />
-        <inertia  ixx="0.1" ixy="0.0"  ixz="0.0"  iyy="0.1"  iyz="0.0" izz="0.01" />
+           <inertia  ixx="0.002" ixy="0.0"  ixz="0.0"  iyy="0.002"  iyz="0.0"
+          izz="0.0002" />
       </inertial>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 1.571" />
@@ -58,16 +59,17 @@
       <child link="${prefix}${link_prefix}adapter"/>
       <origin xyz="0 0 0.045" rpy="0 0 0" />
       <axis xyz="1 0 0" />
-      <limit lower="0" upper="${M_PI/2}" effort="1000.0"
-      velocity="10.0" />
-      <dynamics damping="10.0"/>
+      <limit lower="0" upper="${M_PI/2}" effort="2.0"
+      velocity="1.0" />
+      <dynamics damping="0.10"/>
     </joint>
 
     <link name="${prefix}${link_prefix}_J1_dummy">
       <inertial>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <mass value="0.01" />
-        <inertia  ixx="0.1" ixy="0.0"  ixz="0.0"  iyy="0.1"  iyz="0.0" izz="0.01" />
+         <inertia  ixx="0.002" ixy="0.0"  ixz="0.0"  iyy="0.002"  iyz="0.0"
+          izz="0.0002" />
       </inertial>
     </link>
 
@@ -76,8 +78,8 @@
       <child link="${prefix}${link_prefix}_J1_dummy"/>
       <origin xyz="0 0 0.02" rpy="0 0 0" />
       <axis xyz="1 0 0" />
-      <limit lower="${20*M_PI/180}" upper="${20.1*M_PI/180}" effort="1000.0" velocity="10.0" />
-      <dynamics damping="10.0"/>
+      <limit lower="${20*M_PI/180}" upper="${20.1*M_PI/180}" effort="1.0" velocity="1.0" />
+      <dynamics damping="0.1"/>
     </joint>
 
     <xacro:middle_transmission muscletrans="${muscle}" prefix="${prefix}" joint_prefix="${joint_prefix}" link_prefix="${link_prefix}"/>
@@ -85,8 +87,9 @@
     <link name="${prefix}${link_prefix}biotac">
       <inertial>
         <origin xyz="0 0 0" rpy="0 0 0" />
-        <mass value="0.10" />
-        <inertia  ixx="0.1" ixy="0.0"  ixz="0.0"  iyy="0.1"  iyz="0.0" izz="0.01" />
+        <mass value="0.040" />
+        <inertia  ixx="0.001" ixy="0.0"  ixz="0.0"  iyy="0.001"  iyz="0.0"
+        izz="0.00025" />
       </inertial>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -134,7 +137,7 @@
       <inertial>
        <mass value="0.001" />
        <origin xyz="0 0 0" rpy="0 0 0" />
-       <inertia  ixx="1" ixy="0"  ixz="0"  iyy="1"  iyz="0" izz="1" />
+       <inertia  ixx="0.0" ixy="0.0"  ixz="0.0"  iyy="0.0"  iyz="0.0" izz="0.0" />
       </inertial>
       <visual>
         <geometry>


### PR DESCRIPTION
Fixes #169 but the collision meshes are wrong. Gazebo does not like meshes that intersect even if it should handle successive joints (no collision between them). This creates internal forces on the joint and hinders movements. One should take care if there is a dummy joint in between two joints with intersection collision geoms. 
The biotac geom itself is not only the distal part but has polygons also at the middle part that collide with the adapter collision box. 
So either the biotac collision mesh must be modified to represent only the distal part, 
or the middle collision box must be removed. But then the contact sensor fails to find the geom it refers to. 
It is also cleaner to have separate middle and distal part not intersecting.
