### PR TITLE
Collision model update for palm and forearm

### DIFF
--- a/sr_description/hand/xacro/forearm/forearm.urdf.xacro
+++ b/sr_description/hand/xacro/forearm/forearm.urdf.xacro
@@ -22,25 +22,41 @@
              <mesh filename="package://sr_description/hand/model/forearm.dae" 
              scale="0.001 0.001 0.001"/>
           </xacro:unless> 
-          
+
         </geometry>
         <material name="Grey" />
         </visual>
 
         <collision>
           <xacro:if value="${muscle}">
-            <origin xyz="0 0 0.18" rpy="0 0 0" />
+            <origin xyz="0 0 0.185" rpy="0 0 0" />
             <geometry name="${prefix}forearm_collision">
-              <cylinder radius="0.075" length="0.36"/>
+              <cylinder radius="0.075" length="0.37"/>
             </geometry>
           </xacro:if> 
           <xacro:unless value="${muscle}">
-            <origin xyz="0 0 0.09" rpy="0 0 0" />
+            <origin xyz="0 0 0.092" rpy="0 0 0" />
             <geometry name="${prefix}forearm_collision">
-              <box size="0.140 0.140 0.180" />
+              <box size="0.140 0.140 0.184" />
             </geometry>
           </xacro:unless>
         </collision>
+        <!-- wrist mount -->
+        <collision>
+          <xacro:if value="${muscle}">
+            <origin xyz="0 0 0.395" rpy="0 0 0" />
+            <geometry>
+              <box size="0.03 0.04 0.06"/>
+            </geometry>
+          </xacro:if> 
+          <xacro:unless value="${muscle}">
+            <origin xyz="0 -0.01 0.181" rpy="0 0.78 0" />
+            <geometry>
+              <box size="0.07 0.07 0.07"/>
+            </geometry>
+          </xacro:unless>
+        </collision>
+        
 
       </link>
 

--- a/sr_description/hand/xacro/palm/palm.urdf.xacro
+++ b/sr_description/hand/xacro/palm/palm.urdf.xacro
@@ -31,17 +31,46 @@
       </visual>
 
       <collision>
-        <origin xyz="${reflect*0.011} 0 0.038" rpy="0 0 0" />
+        <origin xyz="${reflect*0.011} 0.0085 0.038" rpy="0 0 0" />
         <geometry name="${prefix}palm_collision_geom">
-          <box size="0.062 0.024 0.098" />
+          <box size="0.062 0.007 0.098" />
         </geometry>
       </collision>
+      <collision>
+        <origin xyz="${reflect*0.0005} -0.0035 0.038" rpy="0 0 0" />
+        <geometry>
+          <box size="0.041 0.017 0.098" />
+        </geometry>
+      </collision>
+      <!-- palm complement below first finger -->
+      <collision>
+        <origin xyz="${reflect*0.0315} -0.0035 0.073" rpy="0 0 0" />
+        <geometry>
+          <box size="0.021 0.017 0.028" />
+        </geometry>
+      </collision> 
+      <!-- thumb pulp side -->
+      <collision>
+        <origin xyz="${reflect*0.0315} -0.0085 0.001" rpy="0 0 0" />
+        <geometry>
+          <box size="0.021 0.027 0.024" />
+        </geometry>
+      </collision> 
+      <!-- thumb pulp central -->
+      <collision>
+        <origin xyz="${reflect*0.01} -0.017 0.011" rpy="0 0 0" />
+        <geometry>
+          <box size="0.022 0.010 0.044" />
+        </geometry>
+      </collision> 
+      <!-- above middle finger-->
       <collision>
         <origin xyz="${reflect*0.011} 0 0.089" rpy="0 0 0" />
         <geometry>
           <box size="0.018 0.024 0.004" />
         </geometry>
       </collision> 
+      <!-- metacarpal side-->
       <collision>
         <origin xyz="${reflect*-0.030} 0 0.009" rpy="0 0 0" />
 	      <geometry>


### PR DESCRIPTION
To avoid self-colliding palm was updated so that thumb does not collide with palm. More box added but still simpler to check than a thousand-face mesh.
The wrist mount was not covered by a collision object, this means a planning algorithm would accept to penetrate the between the forearm and the wrist joint. A box was added to the forearm (different box for muscle and motor to cover the mount and avoid self collision with the palm.

used sr_description/test/tests_hand.sh to verify each existing model for consistency with new collision model
![new_palm-wrist_collision-muscle](https://cloud.githubusercontent.com/assets/6583181/5321797/d6a845f6-7cbe-11e4-986c-97e9d3c1376e.png)
![new_palm-wrist_collision](https://cloud.githubusercontent.com/assets/6583181/5321798/e1ea33de-7cbe-11e4-95e7-74862cebc61b.png)

started simulated hand in gazebo and no collision or vibration observed.
