### PR TITLE
F indigo devel port grasps 2

### DIFF
--- a/sr_grasp/README.md
+++ b/sr_grasp/README.md
@@ -24,10 +24,19 @@ rosrun sr_grasp grasp
 ```
 Now start the quick grasp tool, which provides a quick command line way to run a full hand grasp:
 ```sh
-rosrun sr_grasp quick_grasp 
-[INFO] [WallTime: 1405623038.743846] [0.000000] Looking for hand...
-[INFO] [WallTime: 1405623040.068238] [624.276000] Found
-Enter z for zero hand, g for grasp, p for pre-grasp, q quit:
+rosrun sr_grasp quick_grasp
+[INFO] [WallTime: 1420469735.467177] [2088.184000] Loaded grasps from file: /home/hand/indigo_ws/src/shadow_robot/sr_grasp/resource/grasps.yaml
+[INFO] [WallTime: 1420469735.467525] [2088.184000] Looking for hand...
+[WARN] [WallTime: 1420469738.040228] [2089.002000] No tactile topic found. This is normal for a simulated hand
+[INFO] [WallTime: 1420469738.040807] [2089.002000] Found
+
+Grasps:
+0 - Power Grasp Vertical
+1 - Pinch Horizontal
+2 - Basic full grab
+Current grasp: Power Grasp Vertical
+Number select grasp, z zero hand, g grasp, p pre-grasp, q quit
+: 
 ```
 
 ### Actionlib

--- a/sr_grasp/resource/grasps.yaml
+++ b/sr_grasp/resource/grasps.yaml
@@ -1,0 +1,250 @@
+- id: Basic full grab
+  pre_grasp_posture: 
+    header: 
+      seq: 0
+      stamp: 
+        secs: 0
+        nsecs: 0
+      frame_id: ''
+    joint_names: ['LFJ0', 'LFJ3', 'LFJ4', 'LFJ5', 'RFJ0', 'RFJ3', 'RFJ4', 'MFJ0', 'MFJ3', 'MFJ4', 'FFJ0', 'FFJ3', 'FFJ4', 'THJ1', 'THJ2', 'THJ3', 'THJ4', 'THJ5', 'WRJ1', 'WRJ2']
+    points: 
+      - 
+        positions: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        velocities: []
+        accelerations: []
+        effort: []
+        time_from_start: 
+          secs: 0
+          nsecs: 0
+  grasp_posture: 
+    header: 
+      seq: 0
+      stamp: 
+        secs: 0
+        nsecs: 0
+      frame_id: ''
+    joint_names: ['LFJ0', 'LFJ3', 'LFJ4', 'LFJ5', 'RFJ0', 'RFJ3', 'RFJ4', 'MFJ0', 'MFJ3', 'MFJ4', 'FFJ0', 'FFJ3', 'FFJ4', 'THJ1', 'THJ2', 'THJ3', 'THJ4', 'THJ5', 'WRJ1', 'WRJ2']
+    points: 
+      - 
+        positions: [2.0, 1.4, 0.0, 0.0, 2.0, 1.4, 0.0, 2.0, 1.4, 0.0, 2.0, 1.4, 0.0, 0.4, 0.36, 0.2, 1.23, 0.06, 0.0, 0.0]
+        velocities: []
+        accelerations: []
+        effort: []
+        time_from_start: 
+          secs: 0
+          nsecs: 0
+  grasp_pose: 
+    header: 
+      seq: 0
+      stamp: 
+        secs: 0
+        nsecs: 0
+      frame_id: forearm
+    pose: 
+      position: 
+        x: 0.01
+        y: -0.045
+        z: 0.321
+      orientation: 
+        x: 0.0
+        y: 0.0
+        z: 0.0
+        w: 0.0
+  grasp_quality: 0.001
+
+- id: 'Power Grasp Vertical'
+  pre_grasp_posture: 
+    header: 
+      seq: 0
+      stamp: 
+        secs: 790
+        nsecs: 926000000
+      frame_id: ''
+    joint_names: ['FFJ1', 'FFJ2', 'FFJ3', 'FFJ4', 'LFJ1', 'LFJ2', 'LFJ3', 'LFJ4', 'LFJ5', 'MFJ1', 'MFJ2', 'MFJ3', 'MFJ4', 'RFJ1', 'RFJ2', 'RFJ3', 'RFJ4', 'THJ1', 'THJ2', 'THJ3', 'THJ4', 'THJ5', 'WRJ1', 'WRJ2']
+    points: 
+      - 
+        positions: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.2296, -0.4779, 0.0, 0.0]
+        velocities: []
+        accelerations: []
+        effort: []
+        time_from_start: 
+          secs: 0
+          nsecs: 0
+  grasp_posture: 
+    header: 
+      seq: 0
+      stamp: 
+        secs: 790
+        nsecs: 926000000
+      frame_id: ''
+    joint_names: ['FFJ1', 'FFJ2', 'FFJ3', 'FFJ4', 'LFJ1', 'LFJ2', 'LFJ3', 'LFJ4', 'LFJ5', 'MFJ1', 'MFJ2', 'MFJ3', 'MFJ4', 'RFJ1', 'RFJ2', 'RFJ3', 'RFJ4', 'THJ1', 'THJ2', 'THJ3', 'THJ4', 'THJ5', 'WRJ1', 'WRJ2']
+    points: 
+      - 
+        positions: [1.0, 1.0, 1.4, 0.0, 1.0, 1.0, 1.4, 0.0, 0.0, 1.0, 1.0, 1.4, 0.0, 1.0, 1.0, 1.4, 0.0, 1.0365, 0.6772, 0.1849, 1.2196, 0.0579, 0.0, 0.0]
+        velocities: []
+        accelerations: []
+        effort: []
+        time_from_start: 
+          secs: 0
+          nsecs: 0
+  grasp_pose: 
+    header: 
+      seq: 0
+      stamp: 
+        secs: 790
+        nsecs: 926000000
+      frame_id: forearm
+    pose: 
+      position: 
+        x: 0.02
+        y: -0.085
+        z: 0.333
+      orientation: 
+        x: 0.0
+        y: 0.707106781
+        z: 0.0
+        w: 0.707106781
+  grasp_quality: 0.001
+  pre_grasp_approach: 
+    direction: 
+      header: 
+        seq: 0
+        stamp: 
+          secs: 0
+          nsecs: 0
+        frame_id: ''
+      vector: 
+        x: 0.0
+        y: 0.0
+        z: 0.0
+    desired_distance: 0.0
+    min_distance: 0.0
+  post_grasp_retreat: 
+    direction: 
+      header: 
+        seq: 0
+        stamp: 
+          secs: 0
+          nsecs: 0
+        frame_id: ''
+      vector: 
+        x: 0.0
+        y: 0.0
+        z: 0.0
+    desired_distance: 0.0
+    min_distance: 0.0
+  post_place_retreat: 
+    direction: 
+      header: 
+        seq: 0
+        stamp: 
+          secs: 0
+          nsecs: 0
+        frame_id: ''
+      vector: 
+        x: 0.0
+        y: 0.0
+        z: 0.0
+    desired_distance: 0.0
+    min_distance: 0.0
+  max_contact_force: 0.0
+  allowed_touch_objects: []
+
+- id: 'Pinch Horizontal'
+  pre_grasp_posture: 
+    header: 
+      seq: 0
+      stamp: 
+        secs: 790
+        nsecs: 926000000
+      frame_id: ''
+    joint_names: ['FFJ1', 'FFJ2', 'FFJ3', 'FFJ4', 'LFJ1', 'LFJ2', 'LFJ3', 'LFJ4', 'LFJ5', 'MFJ1', 'MFJ2', 'MFJ3', 'MFJ4', 'RFJ1', 'RFJ2', 'RFJ3', 'RFJ4', 'THJ1', 'THJ2', 'THJ3', 'THJ4', 'THJ5', 'WRJ1', 'WRJ2']
+    points: 
+      - 
+        positions: [0.0, 0.0, 0.8, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.8, 0.0, 0.0, 0.0, 0.0, 0.0, 0.01, 0.008, 0.125, 1.22, -0.2, 0.0, 0.0]
+        velocities: []
+        accelerations: []
+        effort: []
+        time_from_start: 
+          secs: 0
+          nsecs: 0
+  grasp_posture: 
+    header: 
+      seq: 0
+      stamp: 
+        secs: 790
+        nsecs: 926000000
+      frame_id: ''
+    joint_names: ['FFJ1', 'FFJ2', 'FFJ3', 'FFJ4', 'LFJ1', 'LFJ2', 'LFJ3', 'LFJ4', 'LFJ5', 'MFJ1', 'MFJ2', 'MFJ3', 'MFJ4', 'RFJ1', 'RFJ2', 'RFJ3', 'RFJ4', 'THJ1', 'THJ2', 'THJ3', 'THJ4', 'THJ5', 'WRJ1', 'WRJ2']
+    points: 
+      - 
+        positions: [0.02558, 0.35155, 1.5013, -0.01443, -0.0103, 0.03253, -0.00054, -0.00175, 0.01373, 0.01234, 0.43822, 1.54195, 0.27695, -0.00147, -0.00384, -0.01043, 0.01223, -0.00082, 0.0347, 0.12548, 1.13063, 0.48021, 0.0, 0.0]
+        velocities: []
+        accelerations: []
+        effort: []
+        time_from_start: 
+          secs: 0
+          nsecs: 0
+  grasp_pose: 
+    header: 
+      seq: 0
+      stamp: 
+        secs: 790
+        nsecs: 926000000
+      frame_id: forearm
+    pose: 
+      position: 
+        x: 0.02
+        y: -0.085
+        z: 0.333
+      orientation: 
+        x: -0.5
+        y: 0.5
+        z: -0.5
+        w: 0.5
+  grasp_quality: 0.001
+  pre_grasp_approach: 
+    direction: 
+      header: 
+        seq: 0
+        stamp: 
+          secs: 0
+          nsecs: 0
+        frame_id: ''
+      vector: 
+        x: 0.0
+        y: 0.0
+        z: 0.0
+    desired_distance: 0.0
+    min_distance: 0.0
+  post_grasp_retreat: 
+    direction: 
+      header: 
+        seq: 0
+        stamp: 
+          secs: 0
+          nsecs: 0
+        frame_id: ''
+      vector: 
+        x: 0.0
+        y: 0.0
+        z: 0.0
+    desired_distance: 0.0
+    min_distance: 0.0
+  post_place_retreat: 
+    direction: 
+      header: 
+        seq: 0
+        stamp: 
+          secs: 0
+          nsecs: 0
+        frame_id: ''
+      vector: 
+        x: 0.0
+        y: 0.0
+        z: 0.0
+    desired_distance: 0.0
+    min_distance: 0.0
+  max_contact_force: 0.0
+  allowed_touch_objects: []
+

--- a/sr_grasp/scripts/quick_grasp
+++ b/sr_grasp/scripts/quick_grasp
@@ -29,9 +29,11 @@ from sr_grasp import Grasp, GraspStash
 class QuickGraspNode(object):
     def __init__(self):
         self.stash = GraspStash()
-        self.stash.load_yaml_file("grasps.yaml")
+        #self.stash.load_yaml_file("grasps.yaml")
+        self.stash.load_all()
         if self.stash.size() == 0:
-            logerr("No grasps found!")
+            rospy.logerr("No grasps found!")
+            raise Exception("No Grasps")
         else:
             self.grasp = self.stash.get_all()[0]
         #print self.grasp
@@ -61,7 +63,8 @@ class QuickGraspNode(object):
 if __name__ == '__main__':
     rospy.init_node("quick_grasp")
     node = QuickGraspNode()
-    while True:
+    while node:
+        print ""
         print "Grasps:"
         for i, g in enumerate(node.stash.get_all()):
             print str(i) + " - " + g.id

--- a/sr_grasp/scripts/quick_grasp
+++ b/sr_grasp/scripts/quick_grasp
@@ -29,14 +29,12 @@ from sr_grasp import Grasp, GraspStash
 class QuickGraspNode(object):
     def __init__(self):
         self.stash = GraspStash()
-        g = mk_grasp({
-            'LFJ3': 1.4, 'RFJ3': 1.4, 'MFJ3': 1.4, 'FFJ3': 1.4,
-            'LFJ0': 2.0, 'RFJ0': 2.0, 'MFJ0': 2.0, 'FFJ0': 2.0,
-            'THJ1': 0.4, 'THJ2': 0.36, 'THJ3': 0.2, 'THJ4': 1.23, 'THJ5': 0.06, 
-            }, fix_j0=True)
-        g.id = "Full grab"
-        self.stash.put_grasp( g )
-        self.grasp = self.stash.get_all()[0]
+        self.stash.load_yaml_file("grasps.yaml")
+        if self.stash.size() == 0:
+            logerr("No grasps found!")
+        else:
+            self.grasp = self.stash.get_all()[0]
+        #print self.grasp
         rospy.loginfo("Looking for hand...")
         self.hand = ShadowHand_ROS()
         rospy.loginfo("Found")

--- a/sr_grasp/scripts/quick_grasp
+++ b/sr_grasp/scripts/quick_grasp
@@ -62,10 +62,19 @@ if __name__ == '__main__':
     rospy.init_node("quick_grasp")
     node = QuickGraspNode()
     while True:
-        act = raw_input("Enter l list grasps, z zero hand, g grasp, p pre-grasp, q quit: ")
-        if act == "l":
-            for i, g in enumerate(node.stash.get_all()):
-                print str(i) + " - " + g.id
+        print "Grasps:"
+        for i, g in enumerate(node.stash.get_all()):
+            print str(i) + " - " + g.id
+        print "Current grasp: %s"%node.grasp.id
+        print "Number select grasp, z zero hand, g grasp, p pre-grasp, q quit"
+        act = raw_input(": ")
+        num = None
+        try:
+            num = int(act)
+        except ValueError:
+            pass
+        if num is not None:
+            node.grasp = node.stash.get_grasp_at(num)
         elif act == "z":
             node.zero_hand()
         elif act == "p":

--- a/sr_grasp/scripts/quick_grasp
+++ b/sr_grasp/scripts/quick_grasp
@@ -24,14 +24,19 @@ from actionlib import SimpleActionClient, GoalStatus
 from sr_robot_msgs.msg import GraspAction, GraspGoal
 from sr_hand.shadowhand_ros import ShadowHand_ROS
 from sr_grasp.utils import mk_grasp
+from sr_grasp import Grasp, GraspStash
 
 class QuickGraspNode(object):
     def __init__(self):
-        self.grasp = mk_grasp({
+        self.stash = GraspStash()
+        g = mk_grasp({
             'LFJ3': 1.4, 'RFJ3': 1.4, 'MFJ3': 1.4, 'FFJ3': 1.4,
             'LFJ0': 2.0, 'RFJ0': 2.0, 'MFJ0': 2.0, 'FFJ0': 2.0,
             'THJ1': 0.4, 'THJ2': 0.36, 'THJ3': 0.2, 'THJ4': 1.23, 'THJ5': 0.06, 
             }, fix_j0=True)
+        g.id = "Full grab"
+        self.stash.put_grasp( g )
+        self.grasp = self.stash.get_all()[0]
         rospy.loginfo("Looking for hand...")
         self.hand = ShadowHand_ROS()
         rospy.loginfo("Found")
@@ -54,12 +59,16 @@ class QuickGraspNode(object):
         else:
             rospy.logerr("Fail!")
 
+
 if __name__ == '__main__':
     rospy.init_node("quick_grasp")
     node = QuickGraspNode()
     while True:
-        act = raw_input("Enter z for zero hand, g for grasp, p for pre-grasp, q quit: ")
-        if act == "z":
+        act = raw_input("Enter l list grasps, z zero hand, g grasp, p pre-grasp, q quit: ")
+        if act == "l":
+            for i, g in enumerate(node.stash.get_all()):
+                print str(i) + " - " + g.id
+        elif act == "z":
             node.zero_hand()
         elif act == "p":
             node.run_grasp(pre=True)

--- a/sr_grasp/src/sr_grasp/__init__.py
+++ b/sr_grasp/src/sr_grasp/__init__.py
@@ -8,16 +8,14 @@ from sr_grasp.utils import mk_grasp
 
 class Grasp(moveit_msgs.msg.Grasp):
     """
-    Represents a single grasp, basically a warpper around moveit_msgs/Grasp.
+    Represents a single grasp, basically a wrapper around moveit_msgs/Grasp.
     """
     def __init__(self):
         super(Grasp, self).__init__()
 
     @classmethod
     def from_msg(cls, msg):
-        """
-        Construct a shadow grasp object from moveit grasp object.
-        """
+        """Construct a shadow grasp object from moveit grasp object."""
         grasp = Grasp()
         grasp.id = msg.id
         grasp.pre_grasp_posture  = deepcopy(msg.pre_grasp_posture)
@@ -32,18 +30,24 @@ class Grasp(moveit_msgs.msg.Grasp):
         return grasp
 
     def to_msg(self):
-        """
-        Return plain moveit_msgs/Grasp version of self.
-        """
+        """Return plain moveit_msgs/Grasp version of self."""
         raise Exception("TODO - to_msg")
 
     @classmethod
     def from_yaml(self, y):
+        """
+        Construct a shadow grasp object from YAML object. For example YAML
+        grabbed from rostopic to a file.
+        """
         grasp = Grasp()
         genpy.message.fill_message_args(grasp, y)
         return grasp
 
-# Dummy inline store for now, will become - params, file, db etc...
+
+# Store of loaded grasps. Global var as we want multiple instances of the class
+# within a process to share the same data. IE that act like clients. This will
+# make more sense when the grasp shash becomes a proper node with databases and
+# the like.
 _store = {}
 
 class GraspStash(object):
@@ -56,15 +60,11 @@ class GraspStash(object):
         pass
 
     def get_all(self):
-        """
-        Return list of all grasps.
-        """
+        """Return list of all grasps."""
         return _store.values();
 
     def get_grasp(self, id):
-        """
-        Return a single grasp from the stash from it's id field.
-        """
+        """Return a single grasp from the stash from it's id field."""
         Grasp()
         return Grasp;
 
@@ -77,9 +77,7 @@ class GraspStash(object):
         return len(_store)
 
     def put_grasp(self, grasp):
-        """
-        Stash the given grasp, using it's id field, which must be set.
-        """
+        """Stash the given grasp, using it's id field, which must be set."""
         if grasp.id is None or grasp.id == "":
             raise Exception("Grasp has no id")
         # Up convert a plain grasp msg to our wrapper
@@ -88,17 +86,13 @@ class GraspStash(object):
         _store[grasp.id] = grasp
 
     def load_all(self):
-        """
-        Load all configured sources of grasps into the stash.
-        """
+        """Load all configured sources of grasps into the stash."""
         rp = rospkg.RosPack()
         grasp_file = os.path.join(rp.get_path('sr_grasp'), 'resource', 'grasps.yaml')
         self.load_yaml_file(grasp_file)
 
     def load_yaml_file(self, fname):
-        """
-        Load a set of grasps from a YAML file.
-        """
+        """Load a set of grasps from a YAML file."""
         try:
             data = yaml.load(file(fname))
             self.load_yaml(data)
@@ -110,9 +104,7 @@ class GraspStash(object):
             return True
 
     def load_yaml(self, data):
-        """
-        Load a set of grasps from a YAML object. Throws exceptions on errors.
-        """
+        """Load a set of grasps from a YAML object. Throws exceptions on errors."""
         for g in data:
             grasp = Grasp.from_yaml(g)
             self.put_grasp(grasp)

--- a/sr_grasp/src/sr_grasp/__init__.py
+++ b/sr_grasp/src/sr_grasp/__init__.py
@@ -1,8 +1,8 @@
 
 from copy import deepcopy
-import yaml
+import os, yaml
 from rospy import logerr, loginfo
-import genpy
+import rospkg, genpy
 import moveit_msgs.msg
 from sr_grasp.utils import mk_grasp
 
@@ -86,6 +86,14 @@ class GraspStash(object):
         #if isinstance(grasp, moveit_msgs.msg.Grasp):
         #    grasp = Grasp.from_msg(grasp)
         _store[grasp.id] = grasp
+
+    def load_all(self):
+        """
+        Load all configured sources of grasps into the stash.
+        """
+        rp = rospkg.RosPack()
+        grasp_file = os.path.join(rp.get_path('sr_grasp'), 'resource', 'grasps.yaml')
+        self.load_yaml_file(grasp_file)
 
     def load_yaml_file(self, fname):
         """

--- a/sr_grasp/src/sr_grasp/__init__.py
+++ b/sr_grasp/src/sr_grasp/__init__.py
@@ -1,5 +1,8 @@
 
 from copy import deepcopy
+import yaml
+from rospy import logerr, loginfo
+import genpy
 import moveit_msgs.msg
 from sr_grasp.utils import mk_grasp
 
@@ -17,14 +20,14 @@ class Grasp(moveit_msgs.msg.Grasp):
         """
         grasp = Grasp()
         grasp.id = msg.id
-        pre_grasp_posture
-        grasp.grasp_posture = deepcopy(msg.grasp_posture)
-        grasp.grasp_pose = deepcopy(msg.grasp_pose)
-        grasp.grasp_quality = msg.grasp_quality
+        grasp.pre_grasp_posture  = deepcopy(msg.pre_grasp_posture)
+        grasp.grasp_posture      = deepcopy(msg.grasp_posture)
+        grasp.grasp_pose         = deepcopy(msg.grasp_pose)
+        grasp.grasp_quality      = msg.grasp_quality
         grasp.pre_grasp_approach = deepcopy(msg.pre_grasp_approach)
         grasp.post_grasp_retreat = deepcopy(msg.post_grasp_retreat)
         grasp.post_place_retreat = deepcopy(msg.post_place_retreat)
-        grasp.max_contact_force = msg.max_contact_force
+        grasp.max_contact_force  = msg.max_contact_force
         grasp.allowed_touch_objects = deepcopy(msg.allowed_touch_objects)
         return grasp
 
@@ -34,7 +37,13 @@ class Grasp(moveit_msgs.msg.Grasp):
         """
         raise Exception("TODO - to_msg")
 
-# Dummy inline store for now, will become, params, file, db etc...
+    @classmethod
+    def from_yaml(self, y):
+        grasp = Grasp()
+        genpy.message.fill_message_args(grasp, y)
+        return grasp
+
+# Dummy inline store for now, will become - params, file, db etc...
 _store = {}
 
 class GraspStash(object):
@@ -59,6 +68,10 @@ class GraspStash(object):
         Grasp()
         return Grasp;
 
+    def size(self):
+        """Return the number of grasps."""
+        return len(_store)
+
     def put_grasp(self, grasp):
         """
         Stash the given grasp, using it's id field, which must be set.
@@ -69,3 +82,26 @@ class GraspStash(object):
         #if isinstance(grasp, moveit_msgs.msg.Grasp):
         #    grasp = Grasp.from_msg(grasp)
         _store[grasp.id] = grasp
+
+    def load_yaml_file(self, fname):
+        """
+        Load a set of grasps from a YAML file.
+        """
+        try:
+            data = yaml.load(file(fname))
+            self.load_yaml(data)
+        except Exception as e:
+            logerr("Failed to load YAML grasp file: %s error:%s"%(fname, e))
+            return False
+        else:
+            loginfo("Loaded grasps from file: %s"%(fname))
+            return True
+
+    def load_yaml(self, data):
+        """
+        Load a set of grasps from a YAML object. Throws exceptions on errors.
+        """
+        for g in data:
+            grasp = Grasp.from_yaml(g)
+            self.put_grasp(grasp)
+

--- a/sr_grasp/src/sr_grasp/__init__.py
+++ b/sr_grasp/src/sr_grasp/__init__.py
@@ -44,12 +44,6 @@ class Grasp(moveit_msgs.msg.Grasp):
         return grasp
 
 
-# Store of loaded grasps. Global var as we want multiple instances of the class
-# within a process to share the same data. IE that act like clients. This will
-# make more sense when the grasp shash becomes a proper node with databases and
-# the like.
-_store = {}
-
 class GraspStash(object):
     """
     Interface to the list of grasps stored in the system. Clients should all
@@ -57,11 +51,13 @@ class GraspStash(object):
     storage.
     """
     def __init__(self):
+        # Store of all loaded grasps, indexed on grasp.id.
+        self._store = {}
         pass
 
     def get_all(self):
         """Return list of all grasps."""
-        return _store.values();
+        return self._store.values();
 
     def get_grasp(self, id):
         """Return a single grasp from the stash from it's id field."""
@@ -74,7 +70,7 @@ class GraspStash(object):
 
     def size(self):
         """Return the number of grasps."""
-        return len(_store)
+        return len(self._store)
 
     def put_grasp(self, grasp):
         """Stash the given grasp, using it's id field, which must be set."""
@@ -83,7 +79,7 @@ class GraspStash(object):
         # Up convert a plain grasp msg to our wrapper
         #if isinstance(grasp, moveit_msgs.msg.Grasp):
         #    grasp = Grasp.from_msg(grasp)
-        _store[grasp.id] = grasp
+        self._store[grasp.id] = grasp
 
     def load_all(self):
         """Load all configured sources of grasps into the stash."""

--- a/sr_grasp/src/sr_grasp/__init__.py
+++ b/sr_grasp/src/sr_grasp/__init__.py
@@ -68,6 +68,10 @@ class GraspStash(object):
         Grasp()
         return Grasp;
 
+    def get_grasp_at(self, idx):
+        """Return the Grasp at the given index."""
+        return self.get_all()[idx]
+
     def size(self):
         """Return the number of grasps."""
         return len(_store)

--- a/sr_grasp/src/sr_grasp/__init__.py
+++ b/sr_grasp/src/sr_grasp/__init__.py
@@ -1,0 +1,71 @@
+
+from copy import deepcopy
+import moveit_msgs.msg
+from sr_grasp.utils import mk_grasp
+
+class Grasp(moveit_msgs.msg.Grasp):
+    """
+    Represents a single grasp, basically a warpper around moveit_msgs/Grasp.
+    """
+    def __init__(self):
+        super(Grasp, self).__init__()
+
+    @classmethod
+    def from_msg(cls, msg):
+        """
+        Construct a shadow grasp object from moveit grasp object.
+        """
+        grasp = Grasp()
+        grasp.id = msg.id
+        pre_grasp_posture
+        grasp.grasp_posture = deepcopy(msg.grasp_posture)
+        grasp.grasp_pose = deepcopy(msg.grasp_pose)
+        grasp.grasp_quality = msg.grasp_quality
+        grasp.pre_grasp_approach = deepcopy(msg.pre_grasp_approach)
+        grasp.post_grasp_retreat = deepcopy(msg.post_grasp_retreat)
+        grasp.post_place_retreat = deepcopy(msg.post_place_retreat)
+        grasp.max_contact_force = msg.max_contact_force
+        grasp.allowed_touch_objects = deepcopy(msg.allowed_touch_objects)
+        return grasp
+
+    def to_msg(self):
+        """
+        Return plain moveit_msgs/Grasp version of self.
+        """
+        raise Exception("TODO - to_msg")
+
+# Dummy inline store for now, will become, params, file, db etc...
+_store = {}
+
+class GraspStash(object):
+    """
+    Interface to the list of grasps stored in the system. Clients should all
+    use this library so that it can deal with the detail of the undelying
+    storage.
+    """
+    def __init__(self):
+        pass
+
+    def get_all(self):
+        """
+        Return list of all grasps.
+        """
+        return _store.values();
+
+    def get_grasp(self, id):
+        """
+        Return a single grasp from the stash from it's id field.
+        """
+        Grasp()
+        return Grasp;
+
+    def put_grasp(self, grasp):
+        """
+        Stash the given grasp, using it's id field, which must be set.
+        """
+        if grasp.id is None or grasp.id == "":
+            raise Exception("Grasp has no id")
+        # Up convert a plain grasp msg to our wrapper
+        #if isinstance(grasp, moveit_msgs.msg.Grasp):
+        #    grasp = Grasp.from_msg(grasp)
+        _store[grasp.id] = grasp


### PR DESCRIPTION
Do after #186.

Adds the basic backend for reading and storing moveit grasps in a yaml file with a python lib for access. Includes a few grasps. quick_grasp script updated to allow selecting grasps, see README quick start for how to play.
