### PR TITLE
Fixed urdf transmission to be valid urdf for python parser

### DIFF
--- a/sr_description/arm/xacro/hand_support/shadowarm_handsupport_motor.transmission.xacro
+++ b/sr_description/arm/xacro/hand_support/shadowarm_handsupport_motor.transmission.xacro
@@ -9,6 +9,7 @@
     <transmission type="sr_mechanism_model/SimpleTransmission" name="forearm_rotation_transmission">
       <actuator name="forearm_rotation" />
       <joint name="ElbowJRotate" />
+      <mechanicalReduction>1</mechanicalReduction>
     </transmission>
 
   </xacro:macro>

--- a/sr_description/arm/xacro/hand_support/shadowarm_handsupport_muscle.transmission.xacro
+++ b/sr_description/arm/xacro/hand_support/shadowarm_handsupport_muscle.transmission.xacro
@@ -9,6 +9,7 @@
     <transmission type="sr_mechanism_model/SimpleTransmission" name="forearm_rotation_transmission">
       <actuator name="forearm_rotation" />
       <joint name="ElbowJRotate" />
+      <mechanicalReduction>1</mechanicalReduction>
     </transmission>
 
   </xacro:macro>

--- a/sr_description/arm/xacro/lower_arm/shadowarm_lowerarm.transmission.xacro
+++ b/sr_description/arm/xacro/lower_arm/shadowarm_lowerarm.transmission.xacro
@@ -9,6 +9,7 @@
     <transmission type="sr_mechanism_model/SimpleTransmission" name="elbow_abduction_transmission">
       <actuator name="elbow_abduction" />
       <joint name="ElbowJSwing" />
+      <mechanicalReduction>1</mechanicalReduction>
     </transmission>
 
   </xacro:macro>

--- a/sr_description/arm/xacro/trunk/shadowarm_trunk.transmission.xacro
+++ b/sr_description/arm/xacro/trunk/shadowarm_trunk.transmission.xacro
@@ -9,6 +9,7 @@
     <transmission type="sr_mechanism_model/SimpleTransmission" name="trunk_rotation_transmission">
       <actuator name="trunk_rotation" />
       <joint name="ShoulderJRotate" />
+      <mechanicalReduction>1</mechanicalReduction>
     </transmission>
 
   </xacro:macro>

--- a/sr_description/arm/xacro/upper_arm/shadowarm_upperarm.transmission.xacro
+++ b/sr_description/arm/xacro/upper_arm/shadowarm_upperarm.transmission.xacro
@@ -9,6 +9,7 @@
     <transmission type="sr_mechanism_model/SimpleTransmission" name="shoulder_rotation_transmission">
       <actuator name="shoulder_rotation" />
       <joint name="ShoulderJSwing" />
+      <mechanicalReduction>1</mechanicalReduction>
     </transmission>
 
   </xacro:macro>

--- a/sr_description/hand/xacro/finger/distal/distal.transmission.xacro
+++ b/sr_description/hand/xacro/finger/distal/distal.transmission.xacro
@@ -15,6 +15,7 @@
       <transmission type="sr_mechanism_model/SimpleTransmissionForMuscle" name="${prefix}${link_prefix}distal_transmission">
       <actuator name="${prefix}${joint_prefix}J1" />
       <joint name="${prefix}${joint_prefix}J1" />
+      <mechanicalReduction>1</mechanicalReduction>
       </transmission>
     </xacro:if> 
     <!-- motor hand -->
@@ -22,6 +23,7 @@
       <transmission type="sr_mechanism_model/SimpleTransmission" name="${prefix}${link_prefix}distal_transmission">
       <actuator name="${prefix}${joint_prefix}J1" />
       <joint name="${prefix}${joint_prefix}J1" />
+      <mechanicalReduction>1</mechanicalReduction>
       </transmission>
     </xacro:unless> 
   </xacro:macro>

--- a/sr_description/hand/xacro/finger/knuckle/knuckle.transmission.xacro
+++ b/sr_description/hand/xacro/finger/knuckle/knuckle.transmission.xacro
@@ -15,6 +15,7 @@
       <transmission type="sr_mechanism_model/SimpleTransmissionForMuscle" name="${prefix}${link_prefix}knuckle_transmission">
       <actuator name="${prefix}${joint_prefix}J4" />
       <joint name="${prefix}${joint_prefix}J4" />
+      <mechanicalReduction>1</mechanicalReduction>
       </transmission>
     </xacro:if> 
     <!-- motor hand -->
@@ -22,6 +23,7 @@
       <transmission type="sr_mechanism_model/SimpleTransmission" name="${prefix}${link_prefix}knuckle_transmission">
       <actuator name="${prefix}${joint_prefix}J4" />
       <joint name="${prefix}${joint_prefix}J4" />
+      <mechanicalReduction>1</mechanicalReduction>
       </transmission>
     </xacro:unless> 
   

--- a/sr_description/hand/xacro/finger/lfmetacarpal/lfmetacarpal.transmission.xacro
+++ b/sr_description/hand/xacro/finger/lfmetacarpal/lfmetacarpal.transmission.xacro
@@ -13,6 +13,7 @@
       <transmission type="sr_mechanism_model/SimpleTransmissionForMuscle" name="${prefix}lfmetacarpal_transmission">
       <actuator name="${prefix}LFJ5" />
       <joint name="${prefix}LFJ5" />
+      <mechanicalReduction>1</mechanicalReduction>
       </transmission>
     </xacro:if> 
     <!-- motor hand -->
@@ -20,6 +21,7 @@
       <transmission type="sr_mechanism_model/SimpleTransmission" name="${prefix}lfmetacarpal_transmission">
       <actuator name="${prefix}LFJ5" />
       <joint name="${prefix}LFJ5" />
+      <mechanicalReduction>1</mechanicalReduction>
       </transmission>
     </xacro:unless> 
   

--- a/sr_description/hand/xacro/finger/middle/middle.transmission.xacro
+++ b/sr_description/hand/xacro/finger/middle/middle.transmission.xacro
@@ -16,6 +16,7 @@
       <actuator name="${prefix}${joint_prefix}J0" />
       <joint name="${prefix}${joint_prefix}J1" />
       <joint name="${prefix}${joint_prefix}J2" />
+      <mechanicalReduction>1</mechanicalReduction>
       </transmission>
     </xacro:if> 
     <!-- motor hand -->
@@ -24,6 +25,7 @@
       <actuator name="${prefix}${joint_prefix}J0" />
       <joint name="${prefix}${joint_prefix}J1" />
       <joint name="${prefix}${joint_prefix}J2" />
+      <mechanicalReduction>1</mechanicalReduction>
       </transmission>
     </xacro:unless> 
   </xacro:macro>

--- a/sr_description/hand/xacro/finger/proximal/proximal.transmission.xacro
+++ b/sr_description/hand/xacro/finger/proximal/proximal.transmission.xacro
@@ -15,6 +15,7 @@
       <transmission type="sr_mechanism_model/SimpleTransmissionForMuscle" name="${prefix}${link_prefix}proximal_transmission">
       <actuator name="${prefix}${joint_prefix}J3" />
       <joint name="${prefix}${joint_prefix}J3" />
+      <mechanicalReduction>1</mechanicalReduction>
       </transmission>
     </xacro:if> 
     <!-- motor hand -->
@@ -22,6 +23,7 @@
       <transmission type="sr_mechanism_model/SimpleTransmission" name="${prefix}${link_prefix}proximal_transmission">
       <actuator name="${prefix}${joint_prefix}J3" />
       <joint name="${prefix}${joint_prefix}J3" />
+      <mechanicalReduction>1</mechanicalReduction>
       </transmission>
     </xacro:unless> 
   

--- a/sr_description/hand/xacro/palm/palm.transmission.xacro
+++ b/sr_description/hand/xacro/palm/palm.transmission.xacro
@@ -13,6 +13,7 @@
       <transmission type="sr_mechanism_model/SimpleTransmissionForMuscle" name="${prefix}palm_transmission">
       <actuator name="${prefix}WRJ1" />
       <joint name="${prefix}WRJ1" />
+      <mechanicalReduction>1</mechanicalReduction>
       </transmission>
     </xacro:if> 
     <!-- motor hand -->
@@ -20,6 +21,7 @@
       <transmission type="sr_mechanism_model/SimpleTransmission" name="${prefix}palm_transmission">
       <actuator name="${prefix}WRJ1" />
       <joint name="${prefix}WRJ1" />
+      <mechanicalReduction>1</mechanicalReduction>
       </transmission>
     </xacro:unless> 
   

--- a/sr_description/hand/xacro/thumb/thbase.transmission.xacro
+++ b/sr_description/hand/xacro/thumb/thbase.transmission.xacro
@@ -13,6 +13,7 @@
       <transmission type="sr_mechanism_model/SimpleTransmissionForMuscle" name="${prefix}thbase_transmission">
       <actuator name="${prefix}THJ5" />
       <joint name="${prefix}THJ5" />
+      <mechanicalReduction>1</mechanicalReduction>
       </transmission>
     </xacro:if> 
     <!-- motor hand -->
@@ -20,6 +21,7 @@
       <transmission type="sr_mechanism_model/SimpleTransmission" name="${prefix}thbase_transmission">
       <actuator name="${prefix}THJ5" />
       <joint name="${prefix}THJ5" />
+      <mechanicalReduction>1</mechanicalReduction>
       </transmission>
     </xacro:unless> 
   </xacro:macro>

--- a/sr_description/hand/xacro/thumb/thdistal.transmission.xacro
+++ b/sr_description/hand/xacro/thumb/thdistal.transmission.xacro
@@ -13,6 +13,7 @@
       <transmission type="sr_mechanism_model/SimpleTransmissionForMuscle" name="${prefix}thdistal_transmission">
       <actuator name="${prefix}THJ1" />
       <joint name="${prefix}THJ1" />
+      <mechanicalReduction>1</mechanicalReduction>
       </transmission>
     </xacro:if> 
     <!-- motor hand -->
@@ -20,6 +21,7 @@
       <transmission type="sr_mechanism_model/SimpleTransmission" name="${prefix}thdistal_transmission">
       <actuator name="${prefix}THJ1" />
       <joint name="${prefix}THJ1" />
+      <mechanicalReduction>1</mechanicalReduction>
       </transmission>
     </xacro:unless> 
   </xacro:macro>

--- a/sr_description/hand/xacro/thumb/thhub.transmission.xacro
+++ b/sr_description/hand/xacro/thumb/thhub.transmission.xacro
@@ -13,6 +13,7 @@
       <transmission type="sr_mechanism_model/SimpleTransmissionForMuscle" name="${prefix}thhub_transmission">
       <actuator name="${prefix}THJ3" />
       <joint name="${prefix}THJ3" />
+      <mechanicalReduction>1</mechanicalReduction>
       </transmission>
     </xacro:if> 
     <!-- motor hand -->
@@ -20,6 +21,7 @@
       <transmission type="sr_mechanism_model/SimpleTransmission" name="${prefix}thhub_transmission">
       <actuator name="${prefix}THJ3" />
       <joint name="${prefix}THJ3" />
+      <mechanicalReduction>1</mechanicalReduction>
       </transmission>
     </xacro:unless> 
   </xacro:macro>

--- a/sr_description/hand/xacro/thumb/thmiddle.transmission.xacro
+++ b/sr_description/hand/xacro/thumb/thmiddle.transmission.xacro
@@ -13,6 +13,7 @@
       <transmission type="sr_mechanism_model/SimpleTransmissionForMuscle" name="${prefix}thmiddle_transmission">
       <actuator name="${prefix}THJ2" />
       <joint name="${prefix}THJ2" />
+      <mechanicalReduction>1</mechanicalReduction>
       </transmission>
     </xacro:if> 
     <!-- motor hand -->
@@ -20,6 +21,7 @@
       <transmission type="sr_mechanism_model/SimpleTransmission" name="${prefix}thmiddle_transmission">
       <actuator name="${prefix}THJ2" />
       <joint name="${prefix}THJ2" />
+      <mechanicalReduction>1</mechanicalReduction>
       </transmission>
     </xacro:unless> 
   </xacro:macro>

--- a/sr_description/hand/xacro/thumb/thproximal.transmission.xacro
+++ b/sr_description/hand/xacro/thumb/thproximal.transmission.xacro
@@ -13,6 +13,7 @@
       <transmission type="sr_mechanism_model/SimpleTransmissionForMuscle" name="${prefix}thproximal_transmission">
       <actuator name="${prefix}THJ4" />
       <joint name="${prefix}THJ4" />
+      <mechanicalReduction>1</mechanicalReduction>
       </transmission>
     </xacro:if> 
     <!-- motor hand -->
@@ -20,6 +21,7 @@
       <transmission type="sr_mechanism_model/SimpleTransmission" name="${prefix}thproximal_transmission">
       <actuator name="${prefix}THJ4" />
       <joint name="${prefix}THJ4" />
+      <mechanicalReduction>1</mechanicalReduction>
       </transmission>
     </xacro:unless> 
   </xacro:macro>

--- a/sr_description/hand/xacro/wrist/wrist.transmission.xacro
+++ b/sr_description/hand/xacro/wrist/wrist.transmission.xacro
@@ -13,6 +13,7 @@
       <transmission type="sr_mechanism_model/SimpleTransmissionForMuscle" name="${prefix}wrist_transmission">
         <actuator name="${prefix}WRJ2" />
         <joint name="${prefix}WRJ2" />
+        <mechanicalReduction>1</mechanicalReduction>
       </transmission>
     </xacro:if> 
     <!-- motor hand -->
@@ -20,6 +21,7 @@
       <transmission type="sr_mechanism_model/SimpleTransmission" name="${prefix}wrist_transmission">
         <actuator name="${prefix}WRJ2" />
         <joint name="${prefix}WRJ2" />
+        <mechanicalReduction>1</mechanicalReduction>
       </transmission>
     </xacro:unless> 
     


### PR DESCRIPTION
urdf_parser_py tells the urdf is not valid and does not parse it due to an invalid transmission tag. Valid urdf_parsing in python is useful to generate stuff from urdf (srdf for instance).

According to http://wiki.ros.org/urdf/XML/Transmission there are new transmission and old PR2 like transmissions

The parser supports both but the current transmission were none of these.
- new transmission do not work with current sr_gazebo_plugin and co (which read the transmission)
- old transmission work with the added mechanicalReduction. This change does not affect the simulation or the real hand driver
