### PR TITLE
Realistic inertia

### DIFF
--- a/sr_description/arm/config/arm_controller.yaml
+++ b/sr_description/arm/config/arm_controller.yaml
@@ -2,37 +2,37 @@ sa_sr_position_controller:
   type: effort_controllers/JointPositionController
   joint: ShoulderJRotate
   pid:
-    p: 60.0
-    i: 2.0
-    d: 80.0
+    p: 15.0
+    i: 1.0
+    d: 5.0
     i_clamp: 30.0
 
 sa_ss_position_controller:
   type: effort_controllers/JointPositionController
   joint: ShoulderJSwing
   pid:
-    p: 100.0
-    i: 20.0
-    d: 80.0
+    p: 15.0
+    i: 30.0
+    d: 10.0
     i_clamp: 90.0
 
 sa_es_position_controller:
   type: effort_controllers/JointPositionController
   joint: ElbowJSwing
   pid:
-    p: 50.0
-    i: 5.0
-    d: 40.0
+    p: 30.0
+    i: 10.0
+    d: 5.0
     i_clamp: 90.0
 
 sa_er_position_controller:
   type: effort_controllers/JointPositionController
   joint: ElbowJRotate
   pid:
-    p: 50.0
-    i: 5.0
-    d: 50.0
-    i_clamp: 2.0
+    p: 30.0
+    i: 3.0
+    d: 5.0
+    i_clamp: 5.0
 
 r_arm_cartesian_pose_controller:
   type: robot_mechanism_controllers/CartesianPoseController

--- a/sr_description/arm/xacro/base/shadowarm_base.urdf.xacro
+++ b/sr_description/arm/xacro/base/shadowarm_base.urdf.xacro
@@ -7,7 +7,7 @@
     <inertial>
       <origin xyz="0 0 0" rpy="0 0 0"/>
       <mass value="0.4" />
-      <inertia  ixx="0.1" ixy="0.0"  ixz="0.0"  iyy="0.1"  iyz="0.0"  izz="0.1" />
+      <inertia  ixx="0.00071" ixy="0.0"  ixz="0.0"  iyy="0.00071"  iyz="0.0"  izz="0.0014" />
     </inertial>
     <visual>
       <origin xyz="0 0 0" rpy="0 0 0"/>

--- a/sr_description/arm/xacro/hand_support/shadowarm_handsupport_motor.urdf.xacro
+++ b/sr_description/arm/xacro/hand_support/shadowarm_handsupport_motor.urdf.xacro
@@ -8,7 +8,7 @@
       <inertial>
 	<origin xyz="0 0 0" rpy="0 0 0" />
 	<mass value="0.75" />
-	<inertia  ixx="0.01" ixy="0.0"  ixz="0.0"  iyy="0.01"  iyz="0.0"  izz="0.016" />
+	<inertia  ixx="0.00086" ixy="0.0"  ixz="0.0"  iyy="0.00086"  iyz="0.0"  izz="0.0017" />
       </inertial>
       <visual>
 	<origin xyz="0 0 -0.04" rpy="0 0 0"/>
@@ -38,7 +38,10 @@
       effort="30" velocity="1.0"/>
       <dynamics damping="5.5"/>
     </joint>
-
+    <gazebo reference="ElbowJRotate">
+      <provideFeedback>1</provideFeedback>
+      <implicitSpringDamper>1</implicitSpringDamper>
+    </gazebo>
     <xacro:shadowarm_handsupport_motor_transmission />
 
   </xacro:macro>

--- a/sr_description/arm/xacro/hand_support/shadowarm_handsupport_muscle.urdf.xacro
+++ b/sr_description/arm/xacro/hand_support/shadowarm_handsupport_muscle.urdf.xacro
@@ -8,7 +8,7 @@
       <inertial>
 	<origin xyz="0 0 0" rpy="0 0 0" />
 	<mass value="0.75" />
-	<inertia  ixx="0.01" ixy="0.0"  ixz="0.0"  iyy="0.01"  iyz="0.0"  izz="0.016" />
+	<inertia  ixx="0.00092" ixy="0.0"  ixz="0.0"  iyy="0.00092"  iyz="0.0"  izz="0.0018" />
       </inertial>
       <visual>
 	<origin xyz="0 0 -0.04" rpy="${M_PI/2} 0 0"/>
@@ -38,7 +38,10 @@
       effort="30" velocity="1.0"/>
       <dynamics damping="5.5"/>
     </joint>
-
+    <gazebo reference="ElbowJRotate">
+      <provideFeedback>1</provideFeedback>
+      <implicitSpringDamper>1</implicitSpringDamper>
+    </gazebo>
     <xacro:shadowarm_handsupport_muscle_transmission />
 
   </xacro:macro>

--- a/sr_description/arm/xacro/lower_arm/shadowarm_lowerarm.urdf.xacro
+++ b/sr_description/arm/xacro/lower_arm/shadowarm_lowerarm.urdf.xacro
@@ -7,7 +7,7 @@
 	<inertial>
 	  <origin xyz="0.08 0 0.0625" rpy="0 0 0" />
 	  <mass value="1.7" />
-	  <inertia  ixx="0.01" ixy="0.0"  ixz="0.0"  iyy="0.01"  iyz="0.0"  izz="0.01" />
+	  <inertia  ixx="0.0016" ixy="0.0"  ixz="0.0"  iyy="0.0016"  iyz="0.0"  izz="0.0018" />
 	</inertial>
 	<visual>
 	  <origin xyz="0.03 0 0.036" rpy="0 0 0"/>
@@ -37,7 +37,10 @@
       effort="50" velocity="1.0"/>
       <dynamics damping="5.5"/>
     </joint>
-
+    <gazebo reference="ElbowJSwing">
+      <provideFeedback>1</provideFeedback>
+      <implicitSpringDamper>1</implicitSpringDamper>
+    </gazebo>
     <xacro:shadowarm_lowerarm_transmission />
 
   </xacro:macro>

--- a/sr_description/arm/xacro/trunk/shadowarm_trunk.urdf.xacro
+++ b/sr_description/arm/xacro/trunk/shadowarm_trunk.urdf.xacro
@@ -7,7 +7,7 @@
 	<inertial>
 	  <origin xyz="0 0 0.26525" rpy="0 0 0" />
 	  <mass value="10" />
-	  <inertia  ixx="0.15" ixy="0.0"  ixz="0.0"  iyy="0.15"  iyz="0.0"  izz="0.02" />
+	  <inertia  ixx="0.298" ixy="0.0"  ixz="0.0"  iyy="0.298"  iyz="0.0"  izz="0.0361" />
 	</inertial>
 	<visual>
 	  <origin xyz="0 0 0.005" rpy="0 0 0" />
@@ -38,6 +38,11 @@
       <dynamics damping="5.5"/>
     </joint>
 
+    <gazebo reference="ShoulderJRotate">
+      <provideFeedback>1</provideFeedback>
+      <implicitSpringDamper>1</implicitSpringDamper>
+    </gazebo>
+    
     <xacro:shadowarm_trunk_transmission />
 
   </xacro:macro>

--- a/sr_description/arm/xacro/upper_arm/shadowarm_upperarm.urdf.xacro
+++ b/sr_description/arm/xacro/upper_arm/shadowarm_upperarm.urdf.xacro
@@ -7,7 +7,7 @@
       <inertial>
 	<origin xyz="0 0 0.1845" rpy="0 0 0" />
 	<mass value="2" />
-	<inertia  ixx="0.4" ixy="0.0"  ixz="0.0"  iyy="0.4"  iyz="0.0"  izz="0.05" />
+	<inertia  ixx="0.044" ixy="0.0"  ixz="0.0"  iyy="0.044"  iyz="0.0"  izz="0.0056" />
       </inertial>
       <visual>
 	<origin xyz="0 0.067 0" rpy="0 0 0" />
@@ -36,7 +36,10 @@
       <limit lower="0" upper="${M_PI/2}" effort="100" velocity="1.0"/>
       <dynamics damping="5.3"/>
     </joint>
-
+    <gazebo reference="ShoulderJSwing">
+      <provideFeedback>1</provideFeedback>
+      <implicitSpringDamper>1</implicitSpringDamper>
+    </gazebo>
     <xacro:shadowarm_upperarm_transmission />
 
   </xacro:macro>

--- a/sr_description/doc/ArmInertia.txt
+++ b/sr_description/doc/ArmInertia.txt
@@ -1,0 +1,79 @@
+Author Guillaume WALCK gwalck@techfak.uni-bielefeld.de 
+
+work done during the HANDLE project in 2011 (inertia tensor moved to joint axis)
+reworked 2015 (inertia tensor at COM)
+
+Overview
+========
+
+Arm inertia estimated from bounding box or bounding cylinders.
+mass estimated from volume of bounding boxes times density of material 
+computation done with octave
+
+
+Octave functions 
+================
+
+---------------
+function [ix,iy,iz] = inertiabox(sx,sy,sz,mass)
+
+ix = 1/12.0*mass*(sy*sy+sz*sz);
+iy = 1/12.0*mass*(sx*sx+sz*sz);
+iz = 1/12.0*mass*(sy*sy+sx*sx);
+end
+---------------
+function [ix,iy,iz] = inertiacyl(radius,length,mass)
+% along z
+
+iz = mass* radius*radius/2;
+ix = 1/12.0* mass * (3*radius*radius+length*length);
+iy = ix;
+end
+--------------------
+
+
+Inertia Tensors
+===============
+
+-----------------------------
+base aluminum m=400g
+inertiabox(0.145,0.145,0.012,0.4)
+Ix =    7.0563e-04
+Iy =    7.0563e-04
+Iz =  0.0014017
+
+
+-----------------------------
+hand_support_plate_motor aluminum  m=750g
+inertiacyl(0.0675,0.006,0.75)
+Ix =    8.5655e-04
+Iy =    8.5655e-04
+Iz =  0.0017086
+
+-----------------------------
+hand_support_plate_muscle aluminum  m=750g
+inertiacyl(0.07,0.006,0.75)
+Ix =    9.2100e-04
+Iy =    9.2100e-04
+Iz =  0.0018375
+
+-----------------------------
+trunk various material m=10kg
+inertiacyl(0.17/2,0.580,10.0)
+Ix =  0.29840
+Iy =  0.29840
+Iz =  0.036125
+
+----------------------------
+upperarm various material m=2kg
+inertiacyl(0.15/2,0.500,2.0)
+Ix =  0.044479
+Iy =  0.044479
+Iz =  0.0056250
+
+-----------------------------
+lower_arm various material m=1.7kg
+inertiabox(0.080,0.078,0.07,1.7)
+Ix =  0.0015561
+Iy =  0.0016008
+Iz =  0.0017686

--- a/sr_description/doc/HandInertia.txt
+++ b/sr_description/doc/HandInertia.txt
@@ -1,0 +1,124 @@
+Author Guillaume WALCK gwalck@techfak.uni-bielefeld.de 
+
+work done during the HANDLE project in 2011 (inertia tensor moved to joint axis)
+reworked 2015 (inertia tensor at COM)
+
+Overview
+========
+
+Hand inertia estimated from bounding box or bounding cylinders.
+mass estimated from volume of bounding boxes times density of material 
+  (sometimes adjusted to match real values)
+computation done with octave
+
+
+Octave functions 
+================
+
+---------------
+function [ix,iy,iz] = inertiabox(sx,sy,sz,mass)
+
+ix = 1/12.0*mass*(sy*sy+sz*sz);
+iy = 1/12.0*mass*(sx*sx+sz*sz);
+iz = 1/12.0*mass*(sy*sy+sx*sx);
+end
+---------------
+function [ix,iy,iz] = inertiacyl(radius,length,mass)
+% along z
+
+iz = mass* radius*radius/2;
+ix = 1/12.0* mass * (3*radius*radius+length*length);
+iy = ix;
+end
+--------------------
+
+Inertia tensors
+===============
+
+density delrin = 1.41g/cm3
+aluminum density = 2.7g/cm3
+
+---------------------------
+wrist aluminum V=16+37.7/2 = 41cm3 m=100g
+inertiabox(0.030,0.066,0.058,0.1)
+Ix =    6.4333e-05
+Iy =    3.5533e-05
+Iz =    4.3800e-05
+
+---------------------------
+palm delrin V=200cm3 m=300g
+inertiabox(0.085,0.020,0.118,0.30)
+Ix =    3.5810e-04
+Iy =    5.2872e-04
+Iz =    1.9063e-04
+
+---------------------------
+lfmetacarpal V=13cm3 m=30g
+inertiabox(0.035,0.022,0.073,0.030)
+Ix =    1.4532e-05
+Iy =    1.6385e-05
+Iz =    4.2725e-06
+
+--------------------------------
+knuckle aluminum V=3cm3  m=8g
+inertiacyl(0.009,0.012,0.008)
+Ix =    2.5800e-07
+Iy =    2.5800e-07
+Iz =    3.2400e-07
+
+-------------------------------
+proximal delrin V=21cm3 m=30g
+inertiabox(0.02,0.018,0.06,0.030)
+Ix =    9.8100e-06
+Iy =    1.0000e-05
+Iz =    1.8100e-06
+
+-------------------------------
+middle delrin V=12.24cm3 m = 17g 
+inertiabox(0.018,0.017,0.04,0.017)
+Ix =    2.6761e-06
+Iy =    2.7257e-06
+Iz =    8.6842e-07
+
+-------------------------------
+distal delrin + rubber V=7cm3 m=12g
+ inertiabox(0.018,0.0145,0.027,0.012)
+Ix =    9.3925e-07
+Iy =    1.0530e-06
+Iz =    5.3425e-07
+
+-------------------------------
+thdistal delrin + rubber V=13cm3 m=16g
+inertiabox(0.021,0.018,0.035,0.016)
+Ix =    2.0653e-06
+Iy =    2.2213e-06
+Iz =    1.0200e-06
+
+-------------------------------
+thproximal delrin V=29.5cm3  m=40g
+inertiacyl(0.025/2,0.06,0.04)
+Ix =    1.3562e-05
+Iy =    1.3562e-05
+Iz =    3.1250e-06
+
+-------------------------------
+thmiddle delrin V=19.77cm3 m=27g
+inertiacyl(0.022/2,0.052,0.027)
+Ix =    6.9007e-06
+Iy =    6.9007e-06
+Iz =    1.6335e-06
+
+--------------------------------
+thhub  m=5g
+inertiabox(0.005,0.005,0.005,0.005)
+Ix =    2.0833e-08
+Iy =    2.0833e-08
+Iz =    2.0833e-08
+
+------------------------------
+thbase  m=10g
+inertiabox(0.010,0.010,0.010,0.010)
+Ix =    1.6667e-07
+Iy =    1.6667e-07
+Iz =    1.6667e-07
+

--- a/sr_description/hand/config/hand_controller_gazebo.yaml
+++ b/sr_description/hand/config/hand_controller_gazebo.yaml
@@ -1,219 +1,239 @@
 sh_ffj0_position_controller:
   joint: FFJ0
   pid:
-    d: 0.0
-    i: 0.05
-    i_clamp: 0.2
-    p: 0.02
+    d: 0.005
+    i: 0.1
+    i_clamp: 0.05
+    p: 0.5
     position_deadband: 0.0
-    max_force: 10.0
+    friction_deadband: 0.0
+    max_force: 1.0
   type: sr_mechanism_controllers/SrhJointPositionController
 
 sh_ffj3_position_controller:
   joint: FFJ3
   pid:
-    d: 0.0
-    i: 0.05
+    d: 0.05
+    i: 0.2
     i_clamp: 0.2
-    p: 0.02
+    p: 1.0
     position_deadband: 0.0
-    max_force: 10.0
+    friction_deadband: 0.0
+    max_force: 1.0
   type: sr_mechanism_controllers/SrhJointPositionController
 
 sh_ffj4_position_controller:
   joint: FFJ4
   pid:
-    d: 0.0
-    i: 0.01
-    i_clamp: 0.1
-    p: 0.03
+    d: 0.05
+    i: 0.2
+    i_clamp: 0.2
+    p: 1.0
     position_deadband: 0.0
-    max_force: 10.0
+    friction_deadband: 0.0
+    max_force: 1.0
   type: sr_mechanism_controllers/SrhJointPositionController
 
 sh_lfj0_position_controller:
   joint: LFJ0
   pid:
-    d: 0.0
-    i: 0.05
-    i_clamp: 0.2
-    p: 0.02
+    d: 0.005
+    i: 0.1
+    i_clamp: 0.05
+    p: 0.5
     position_deadband: 0.0
-    max_force: 10.0
+    friction_deadband: 0.0
+    max_force: 1.0
   type: sr_mechanism_controllers/SrhJointPositionController
 
 sh_lfj3_position_controller:
   joint: LFJ3
   pid:
-    d: 0.0
-    i: 0.05
+    d: 0.05
+    i: 0.2
     i_clamp: 0.2
-    p: 0.02
+    p: 1.0
     position_deadband: 0.0
-    max_force: 10.0
+    friction_deadband: 0.0
+    max_force: 1.0
   type: sr_mechanism_controllers/SrhJointPositionController
 
 sh_lfj4_position_controller:
   joint: LFJ4
   pid:
-    d: 0.0
-    i: 0.01
-    i_clamp: 0.1
-    p: 0.03
+    d: 0.05
+    i: 0.2
+    i_clamp: 0.2
+    p: 1.0
     position_deadband: 0.0
-    max_force: 10.0
+    friction_deadband: 0.0
+    max_force: 1.0
   type: sr_mechanism_controllers/SrhJointPositionController
 
 sh_lfj5_position_controller:
   joint: LFJ5
   pid:
-    d: 0.0
-    i: 0.02
-    i_clamp: 0.05
-    p: 0.01
+    d: 0.05
+    i: 0.2
+    i_clamp: 0.2
+    p: 1.0
     position_deadband: 0.0
-    max_force: 10.0
+    friction_deadband: 0.0
+    max_force: 1.0
   type: sr_mechanism_controllers/SrhJointPositionController
 
 sh_mfj0_position_controller:
   joint: MFJ0
   pid:
-    d: 0.0
-    i: 0.05
-    i_clamp: 0.2
-    p: 0.02
+    d: 0.005
+    i: 0.1
+    i_clamp: 0.05
+    p: 0.5
     position_deadband: 0.0
-    max_force: 10.0
+    friction_deadband: 0.0
+    max_force: 1.0
   type: sr_mechanism_controllers/SrhJointPositionController
 
 sh_mfj3_position_controller:
   joint: MFJ3
   pid:
-    d: 0.0
-    i: 0.05
+    d: 0.05
+    i: 0.2
     i_clamp: 0.2
-    p: 0.02
+    p: 1.0
     position_deadband: 0.0
-    max_force: 10.0
+    friction_deadband: 0.0
+    max_force: 1.0
   type: sr_mechanism_controllers/SrhJointPositionController
 
 sh_mfj4_position_controller:
   joint: MFJ4
   pid:
-    d: 0.0
-    i: 0.01
-    i_clamp: 0.1
-    p: 0.03
+    d: 0.05
+    i: 0.2
+    i_clamp: 0.2
+    p: 1.0
     position_deadband: 0.0
-    max_force: 10.0
+    friction_deadband: 0.0
+    max_force: 1.0
   type: sr_mechanism_controllers/SrhJointPositionController
 
 sh_rfj0_position_controller:
   joint: RFJ0
   pid:
-    d: 0.0
-    i: 0.05
-    i_clamp: 0.2
-    p: 0.02
+    d: 0.005
+    i: 0.1
+    i_clamp: 0.05
+    p: 0.5
     position_deadband: 0.0
-    max_force: 10.0
+    friction_deadband: 0.0
+    max_force: 1.0
   type: sr_mechanism_controllers/SrhJointPositionController
 
 sh_rfj3_position_controller:
   joint: RFJ3
   pid:
-    d: 0.0
-    i: 0.05
+    d: 0.05
+    i: 0.2
     i_clamp: 0.2
-    p: 0.02
+    p: 1.0
     position_deadband: 0.0
-    max_force: 10.0
+    friction_deadband: 0.0
+    max_force: 1.0
   type: sr_mechanism_controllers/SrhJointPositionController
 
 sh_rfj4_position_controller:
   joint: RFJ4
   pid:
-    d: 0.0
-    i: 0.01
-    i_clamp: 0.1
-    p: 0.03
+    d: 0.05
+    i: 0.2
+    i_clamp: 0.2
+    p: 1.0
     position_deadband: 0.0
-    max_force: 10.0
+    friction_deadband: 0.0
+    max_force: 1.0
   type: sr_mechanism_controllers/SrhJointPositionController
 
 sh_thj1_position_controller:
   joint: THJ1
   pid:
-    d: 0.05
-    i: 0.01
-    i_clamp: 0.1
-    p: 0.03
+    d: 0.0
+    i: 0.2
+    i_clamp: 0.2
+    p: 1.0
     position_deadband: 0.0
-    max_force: 10.0
+    friction_deadband: 0.0
+    max_force: 1.0
   type: sr_mechanism_controllers/SrhJointPositionController
 
 sh_thj2_position_controller:
   joint: THJ2
   pid:
-    d: 0.05
-    i: 0.01
-    i_clamp: 0.1
-    p: 0.03
+    d: 0.0
+    i: 0.7
+    i_clamp: 0.4
+    p: 1.5
     position_deadband: 0.0
-    max_force: 10.0
+    friction_deadband: 0.0
+    max_force: 1.0
   type: sr_mechanism_controllers/SrhJointPositionController
 
 sh_thj3_position_controller:
   joint: THJ3
   pid:
     d: 0.0
-    i: 0.05
+    i: 0.2
     i_clamp: 0.2
-    p: 0.02
+    p: 0.5
     position_deadband: 0.0
-    max_force: 10.0
+    friction_deadband: 0.0
+    max_force: 1.0
   type: sr_mechanism_controllers/SrhJointPositionController
 
 sh_thj4_position_controller:
   joint: THJ4
   pid:
-    d: 2.0
-    i: 10.0
-    i_clamp: 4.0
-    p: 15.0
+    d: 0.0
+    i: 0.4
+    i_clamp: 0.3
+    p: 1.0
     position_deadband: 0.0
-    max_force: 10.0
+    friction_deadband: 0.0
+    max_force: 2.0
   type: sr_mechanism_controllers/SrhJointPositionController
 
 sh_thj5_position_controller:
   joint: THJ5
   pid:
-    d: 2.0
-    i: 10.0
-    i_clamp: 4.0
-    p: 15.0
+    d: 0.05
+    i: 0.1
+    i_clamp: 0.4
+    p: 0.4
     position_deadband: 0.0
-    max_force: 10.0
+    friction_deadband: 0.0
+    max_force: 3.0
   type: sr_mechanism_controllers/SrhJointPositionController
 
 sh_wrj1_position_controller:
   joint: WRJ1
   pid:
-    d: 2.0
-    i: 10.0
-    i_clamp: 4.0
-    p: 15.0
+    d: 1.0
+    i: 1.5
+    i_clamp: 0.8
+    p: 10.0
     position_deadband: 0.0
-    max_force: 30.0
+    friction_deadband: 0.0
+    max_force: 5.0
   type: sr_mechanism_controllers/SrhJointPositionController
 
 sh_wrj2_position_controller:
   joint: WRJ2
   pid:
-    d: 2.0
-    i: 10.0
-    i_clamp: 4.0
-    p: 15.0
+    d: 0.2
+    i: 1.5
+    i_clamp: 0.5
+    p: 8.0
     position_deadband: 0.0
-    max_force: 20.0
+    friction_deadband: 0.0
+    max_force: 10.0
   type: sr_mechanism_controllers/SrhJointPositionController

--- a/sr_description/hand/config/hand_controller_gazebo.yaml
+++ b/sr_description/hand/config/hand_controller_gazebo.yaml
@@ -1,10 +1,10 @@
 sh_ffj0_position_controller:
   joint: FFJ0
   pid:
-    d: 1.5
-    i: 0.5
-    i_clamp: 1.5
-    p: 5.0
+    d: 0.0
+    i: 0.05
+    i_clamp: 0.2
+    p: 0.02
     position_deadband: 0.0
     max_force: 10.0
   type: sr_mechanism_controllers/SrhJointPositionController
@@ -12,10 +12,10 @@ sh_ffj0_position_controller:
 sh_ffj3_position_controller:
   joint: FFJ3
   pid:
-    d: 1.5
-    i: 0.5
-    i_clamp: 1.5
-    p: 5.0
+    d: 0.0
+    i: 0.05
+    i_clamp: 0.2
+    p: 0.02
     position_deadband: 0.0
     max_force: 10.0
   type: sr_mechanism_controllers/SrhJointPositionController
@@ -23,10 +23,10 @@ sh_ffj3_position_controller:
 sh_ffj4_position_controller:
   joint: FFJ4
   pid:
-    d: 1.5
-    i: 0.5
-    i_clamp: 1.5
-    p: 5.0
+    d: 0.0
+    i: 0.01
+    i_clamp: 0.1
+    p: 0.03
     position_deadband: 0.0
     max_force: 10.0
   type: sr_mechanism_controllers/SrhJointPositionController
@@ -34,10 +34,10 @@ sh_ffj4_position_controller:
 sh_lfj0_position_controller:
   joint: LFJ0
   pid:
-    d: 1.5
-    i: 0.5
-    i_clamp: 1.5
-    p: 5.0
+    d: 0.0
+    i: 0.05
+    i_clamp: 0.2
+    p: 0.02
     position_deadband: 0.0
     max_force: 10.0
   type: sr_mechanism_controllers/SrhJointPositionController
@@ -45,10 +45,10 @@ sh_lfj0_position_controller:
 sh_lfj3_position_controller:
   joint: LFJ3
   pid:
-    d: 1.5
-    i: 0.5
-    i_clamp: 1.5
-    p: 5.0
+    d: 0.0
+    i: 0.05
+    i_clamp: 0.2
+    p: 0.02
     position_deadband: 0.0
     max_force: 10.0
   type: sr_mechanism_controllers/SrhJointPositionController
@@ -56,10 +56,10 @@ sh_lfj3_position_controller:
 sh_lfj4_position_controller:
   joint: LFJ4
   pid:
-    d: 1.5
-    i: 0.5
-    i_clamp: 1.5
-    p: 5.0
+    d: 0.0
+    i: 0.01
+    i_clamp: 0.1
+    p: 0.03
     position_deadband: 0.0
     max_force: 10.0
   type: sr_mechanism_controllers/SrhJointPositionController
@@ -67,10 +67,10 @@ sh_lfj4_position_controller:
 sh_lfj5_position_controller:
   joint: LFJ5
   pid:
-    d: 1.5
-    i: 0.5
-    i_clamp: 1.5
-    p: 5.0
+    d: 0.0
+    i: 0.02
+    i_clamp: 0.05
+    p: 0.01
     position_deadband: 0.0
     max_force: 10.0
   type: sr_mechanism_controllers/SrhJointPositionController
@@ -78,10 +78,10 @@ sh_lfj5_position_controller:
 sh_mfj0_position_controller:
   joint: MFJ0
   pid:
-    d: 1.5
-    i: 0.5
-    i_clamp: 1.5
-    p: 5.0
+    d: 0.0
+    i: 0.05
+    i_clamp: 0.2
+    p: 0.02
     position_deadband: 0.0
     max_force: 10.0
   type: sr_mechanism_controllers/SrhJointPositionController
@@ -89,10 +89,10 @@ sh_mfj0_position_controller:
 sh_mfj3_position_controller:
   joint: MFJ3
   pid:
-    d: 1.5
-    i: 0.5
-    i_clamp: 1.5
-    p: 5.0
+    d: 0.0
+    i: 0.05
+    i_clamp: 0.2
+    p: 0.02
     position_deadband: 0.0
     max_force: 10.0
   type: sr_mechanism_controllers/SrhJointPositionController
@@ -100,10 +100,10 @@ sh_mfj3_position_controller:
 sh_mfj4_position_controller:
   joint: MFJ4
   pid:
-    d: 1.5
-    i: 0.5
-    i_clamp: 1.5
-    p: 5.0
+    d: 0.0
+    i: 0.01
+    i_clamp: 0.1
+    p: 0.03
     position_deadband: 0.0
     max_force: 10.0
   type: sr_mechanism_controllers/SrhJointPositionController
@@ -111,10 +111,10 @@ sh_mfj4_position_controller:
 sh_rfj0_position_controller:
   joint: RFJ0
   pid:
-    d: 1.5
-    i: 0.5
-    i_clamp: 1.5
-    p: 5.0
+    d: 0.0
+    i: 0.05
+    i_clamp: 0.2
+    p: 0.02
     position_deadband: 0.0
     max_force: 10.0
   type: sr_mechanism_controllers/SrhJointPositionController
@@ -122,10 +122,10 @@ sh_rfj0_position_controller:
 sh_rfj3_position_controller:
   joint: RFJ3
   pid:
-    d: 1.5
-    i: 0.5
-    i_clamp: 1.5
-    p: 5.0
+    d: 0.0
+    i: 0.05
+    i_clamp: 0.2
+    p: 0.02
     position_deadband: 0.0
     max_force: 10.0
   type: sr_mechanism_controllers/SrhJointPositionController
@@ -133,10 +133,10 @@ sh_rfj3_position_controller:
 sh_rfj4_position_controller:
   joint: RFJ4
   pid:
-    d: 1.5
-    i: 0.5
-    i_clamp: 1.5
-    p: 5.0
+    d: 0.0
+    i: 0.01
+    i_clamp: 0.1
+    p: 0.03
     position_deadband: 0.0
     max_force: 10.0
   type: sr_mechanism_controllers/SrhJointPositionController
@@ -144,10 +144,10 @@ sh_rfj4_position_controller:
 sh_thj1_position_controller:
   joint: THJ1
   pid:
-    d: 0.0 #otherwise oscillates
-    i: 0.5
-    i_clamp: 1.5
-    p: 5.0
+    d: 0.05
+    i: 0.01
+    i_clamp: 0.1
+    p: 0.03
     position_deadband: 0.0
     max_force: 10.0
   type: sr_mechanism_controllers/SrhJointPositionController
@@ -155,10 +155,10 @@ sh_thj1_position_controller:
 sh_thj2_position_controller:
   joint: THJ2
   pid:
-    d: 1.5
-    i: 0.5
-    i_clamp: 1.5
-    p: 5.0
+    d: 0.05
+    i: 0.01
+    i_clamp: 0.1
+    p: 0.03
     position_deadband: 0.0
     max_force: 10.0
   type: sr_mechanism_controllers/SrhJointPositionController
@@ -166,10 +166,10 @@ sh_thj2_position_controller:
 sh_thj3_position_controller:
   joint: THJ3
   pid:
-    d: 1.5
-    i: 0.5
-    i_clamp: 1.5
-    p: 5.0
+    d: 0.0
+    i: 0.05
+    i_clamp: 0.2
+    p: 0.02
     position_deadband: 0.0
     max_force: 10.0
   type: sr_mechanism_controllers/SrhJointPositionController
@@ -177,32 +177,32 @@ sh_thj3_position_controller:
 sh_thj4_position_controller:
   joint: THJ4
   pid:
-    d: 1.5
-    i: 0.5
-    i_clamp: 1.5
-    p: 5.0
+    d: 2.0
+    i: 10.0
+    i_clamp: 4.0
+    p: 15.0
     position_deadband: 0.0
-    max_force: 30.0
+    max_force: 10.0
   type: sr_mechanism_controllers/SrhJointPositionController
 
 sh_thj5_position_controller:
   joint: THJ5
   pid:
-    d: 1.5
-    i: 0.5
-    i_clamp: 1.5
-    p: 5.0
+    d: 2.0
+    i: 10.0
+    i_clamp: 4.0
+    p: 15.0
     position_deadband: 0.0
-    max_force: 30.0
+    max_force: 10.0
   type: sr_mechanism_controllers/SrhJointPositionController
 
 sh_wrj1_position_controller:
   joint: WRJ1
   pid:
-    d: 1.5
-    i: 0.5
-    i_clamp: 1.5
-    p: 5.0
+    d: 2.0
+    i: 10.0
+    i_clamp: 4.0
+    p: 15.0
     position_deadband: 0.0
     max_force: 30.0
   type: sr_mechanism_controllers/SrhJointPositionController
@@ -210,10 +210,10 @@ sh_wrj1_position_controller:
 sh_wrj2_position_controller:
   joint: WRJ2
   pid:
-    d: 1.5
-    i: 0.5
-    i_clamp: 1.5
-    p: 5.0
+    d: 2.0
+    i: 10.0
+    i_clamp: 4.0
+    p: 15.0
     position_deadband: 0.0
-    max_force: 30.0
+    max_force: 20.0
   type: sr_mechanism_controllers/SrhJointPositionController

--- a/sr_description/hand/config/hand_mixed_controller_gazebo.yaml
+++ b/sr_description/hand/config/hand_mixed_controller_gazebo.yaml
@@ -15,7 +15,7 @@ sh_ffj0_mixed_position_velocity_controller:
     i: 0.0
     i_clamp: 0.0
     max_force: 10.0
-    p: -20.0
+    p: -0.2
 
 sh_ffj3_mixed_position_velocity_controller:
   joint: FFJ3
@@ -34,7 +34,7 @@ sh_ffj3_mixed_position_velocity_controller:
     i: 0.0
     i_clamp: 0.0
     max_force: 10.0
-    p: -20.0
+    p: -0.2
 
 sh_ffj4_mixed_position_velocity_controller:
   joint: FFJ4
@@ -53,7 +53,7 @@ sh_ffj4_mixed_position_velocity_controller:
     i: 0.0
     i_clamp: 0.0
     max_force: 10.0
-    p: -20.0
+    p: -0.2
 
 sh_lfj0_mixed_position_velocity_controller:
   joint: LFJ0
@@ -72,7 +72,7 @@ sh_lfj0_mixed_position_velocity_controller:
     i: 0.0
     i_clamp: 0.0
     max_force: 10.0
-    p: -20.0
+    p: -0.2
 
 sh_lfj3_mixed_position_velocity_controller:
   joint: LFJ3
@@ -91,7 +91,7 @@ sh_lfj3_mixed_position_velocity_controller:
     i: 0.0
     i_clamp: 0.0
     max_force: 10.0
-    p: -20.0
+    p: -0.2
 
 sh_lfj4_mixed_position_velocity_controller:
   joint: LFJ4
@@ -110,7 +110,7 @@ sh_lfj4_mixed_position_velocity_controller:
     i: 0.0
     i_clamp: 0.0
     max_force: 10.0
-    p: -20.0
+    p: -0.2
 
 sh_lfj5_mixed_position_velocity_controller:
   joint: LFJ5
@@ -129,7 +129,7 @@ sh_lfj5_mixed_position_velocity_controller:
     i: 0.0
     i_clamp: 0.0
     max_force: 10.0
-    p: -20.0
+    p: -0.2
 
 sh_mfj0_mixed_position_velocity_controller:
   joint: MFJ0
@@ -148,7 +148,7 @@ sh_mfj0_mixed_position_velocity_controller:
     i: 0.0
     i_clamp: 0.0
     max_force: 10.0
-    p: -20.0
+    p: -0.2
 
 sh_mfj3_mixed_position_velocity_controller:
   joint: MFJ3
@@ -167,7 +167,7 @@ sh_mfj3_mixed_position_velocity_controller:
     i: 0.0
     i_clamp: 0.0
     max_force: 10.0
-    p: -20.0
+    p: -0.2
 
 sh_mfj4_mixed_position_velocity_controller:
   joint: MFJ4
@@ -186,7 +186,7 @@ sh_mfj4_mixed_position_velocity_controller:
     i: 0.0
     i_clamp: 0.0
     max_force: 10.0
-    p: -20.0
+    p: -0.2
 
 sh_rfj0_mixed_position_velocity_controller:
   joint: RFJ0
@@ -205,7 +205,7 @@ sh_rfj0_mixed_position_velocity_controller:
     i: 0.0
     i_clamp: 0.0
     max_force: 10.0
-    p: -20.0
+    p: -0.2
 
 sh_rfj3_mixed_position_velocity_controller:
   joint: RFJ3
@@ -224,7 +224,7 @@ sh_rfj3_mixed_position_velocity_controller:
     i: 0.0
     i_clamp: 0.0
     max_force: 10.0
-    p: -20.0
+    p: -0.2
 
 sh_rfj4_mixed_position_velocity_controller:
   joint: RFJ4
@@ -243,7 +243,7 @@ sh_rfj4_mixed_position_velocity_controller:
     i: 0.0
     i_clamp: 0.0
     max_force: 10.0
-    p: -20.0
+    p: -0.2
 
 sh_thj1_mixed_position_velocity_controller:
   joint: THJ1
@@ -262,7 +262,7 @@ sh_thj1_mixed_position_velocity_controller:
     i: 0.0
     i_clamp: 0.0
     max_force: 10.0
-    p: -20.0
+    p: -0.2
 
 sh_thj2_mixed_position_velocity_controller:
   joint: THJ2
@@ -281,7 +281,7 @@ sh_thj2_mixed_position_velocity_controller:
     i: 0.0
     i_clamp: 0.0
     max_force: 10.0
-    p: -20.0
+    p: -0.2
 
 sh_thj3_mixed_position_velocity_controller:
   joint: THJ3
@@ -300,7 +300,7 @@ sh_thj3_mixed_position_velocity_controller:
     i: 0.0
     i_clamp: 0.0
     max_force: 10.0
-    p: -20.0
+    p: -0.2
 
 sh_thj4_mixed_position_velocity_controller:
   joint: THJ4
@@ -319,7 +319,7 @@ sh_thj4_mixed_position_velocity_controller:
     i: 0.0
     i_clamp: 0.0
     max_force: 10.0
-    p: -20.0
+    p: -0.2
 
 sh_thj5_mixed_position_velocity_controller:
   joint: THJ5
@@ -338,7 +338,7 @@ sh_thj5_mixed_position_velocity_controller:
     i: 0.0
     i_clamp: 0.0
     max_force: 10.0
-    p: -20.0
+    p: -0.2
 
 sh_wrj1_mixed_position_velocity_controller:
   joint: WRJ1
@@ -357,7 +357,7 @@ sh_wrj1_mixed_position_velocity_controller:
     i: 0.0
     i_clamp: 0.0
     max_force: 10.0
-    p: -20.0
+    p: -0.2
 
 sh_wrj2_mixed_position_velocity_controller:
   joint: WRJ2
@@ -376,6 +376,6 @@ sh_wrj2_mixed_position_velocity_controller:
     i: 0.0
     i_clamp: 0.0
     max_force: 10.0
-    p: -20.0
+    p: -0.2
 
 

--- a/sr_description/hand/xacro/finger/biotac/biotac.urdf.xacro
+++ b/sr_description/hand/xacro/finger/biotac/biotac.urdf.xacro
@@ -61,7 +61,7 @@
       <axis xyz="1 0 0" />
       <limit lower="0" upper="${M_PI/2}" effort="2.0"
       velocity="1.0" />
-      <dynamics damping="0.10"/>
+      <dynamics damping="0.001"/> 
     </joint>
 
     <link name="${prefix}${link_prefix}_J1_dummy">
@@ -79,7 +79,7 @@
       <origin xyz="0 0 0.02" rpy="0 0 0" />
       <axis xyz="1 0 0" />
       <limit lower="${20*M_PI/180}" upper="${20.1*M_PI/180}" effort="1.0" velocity="1.0" />
-      <dynamics damping="0.1"/>
+      <dynamics damping="0.001"/> 
     </joint>
 
     <xacro:middle_transmission muscletrans="${muscle}" prefix="${prefix}" joint_prefix="${joint_prefix}" link_prefix="${link_prefix}"/>

--- a/sr_description/hand/xacro/finger/biotac/biotac.urdf.xacro
+++ b/sr_description/hand/xacro/finger/biotac/biotac.urdf.xacro
@@ -18,9 +18,9 @@
     <link name="${prefix}${link_prefix}adapter">
       <inertial>
         <origin xyz="0 0 0.0125" rpy="0 0 0" />
-        <mass value="0.012" />
-           <inertia  ixx="0.002" ixy="0.0"  ixz="0.0"  iyy="0.002"  iyz="0.0"
-          izz="0.0002" />
+          <mass value="0.017" />
+        <inertia  ixx="0.0000026" ixy="0.0"  ixz="0.0"  iyy="0.0000027"  iyz="0.0"
+        izz="0.00000087" />
       </inertial>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 1.571" />
@@ -30,9 +30,9 @@
         <material name="LightGrey" />
       </visual>
       <collision>
-        <origin xyz="0 0 0.0125" rpy="0 0 0" />
+        <origin xyz="0 0 0.005" rpy="0 0 0" />
         <geometry name="${prefix}${link_prefix}adapter_collision_geom">
-          <box size="0.008 0.008 0.03" />
+          <box size="0.001 0.001 0.001" />
         </geometry>
       </collision>
     </link>
@@ -51,7 +51,7 @@
 	  <bumperTopicName>contacts/${prefix}${link_prefix}/adapter</bumperTopicName>
         </plugin>
       </sensor>
-      <material>Gazebo/Grey</material>
+      <material>Gazebo/FlatBlack</material>
     </gazebo>
 
     <joint name="${prefix}${joint_prefix}J2" type="revolute">
@@ -60,16 +60,21 @@
       <origin xyz="0 0 0.045" rpy="0 0 0" />
       <axis xyz="1 0 0" />
       <limit lower="0" upper="${M_PI/2}" effort="2.0"
-      velocity="1.0" />
-      <dynamics damping="0.001"/> 
+      velocity="2.0" />
+      <dynamics damping="0.1"/>      
     </joint>
+    
+    <gazebo reference="${prefix}${joint_prefix}J2">
+      <provideFeedback>1</provideFeedback>
+      <implicitSpringDamper>1</implicitSpringDamper>
+    </gazebo> 
 
     <link name="${prefix}${link_prefix}_J1_dummy">
       <inertial>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <mass value="0.01" />
-         <inertia  ixx="0.002" ixy="0.0"  ixz="0.0"  iyy="0.002"  iyz="0.0"
-          izz="0.0002" />
+        <origin xyz="0 0 0.012" />
+        <mass value="0.001" />
+             <inertia  ixx="0.00000001" ixy="0.0"  ixz="0.0"  iyy="0.00000001"  iyz="0.0"
+				izz="0.00000001" />
       </inertial>
     </link>
 
@@ -78,18 +83,23 @@
       <child link="${prefix}${link_prefix}_J1_dummy"/>
       <origin xyz="0 0 0.02" rpy="0 0 0" />
       <axis xyz="1 0 0" />
-      <limit lower="${20*M_PI/180}" upper="${20.1*M_PI/180}" effort="1.0" velocity="1.0" />
-      <dynamics damping="0.001"/> 
+      <limit lower="${20*M_PI/180}" upper="${20.1*M_PI/180}" effort="0.0" velocity="2.0" />
+      <dynamics damping="0.5"/>      
     </joint>
+    
+    <gazebo reference="${prefix}${joint_prefix}J1">
+      <provideFeedback>1</provideFeedback>
+      <implicitSpringDamper>1</implicitSpringDamper>
+    </gazebo> 
 
     <xacro:middle_transmission muscletrans="${muscle}" prefix="${prefix}" joint_prefix="${joint_prefix}" link_prefix="${link_prefix}"/>
 
     <link name="${prefix}${link_prefix}biotac">
-      <inertial>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <mass value="0.040" />
-        <inertia  ixx="0.001" ixy="0.0"  ixz="0.0"  iyy="0.001"  iyz="0.0"
-        izz="0.00025" />
+      <inertial>  
+        <origin xyz="0.0 -0.009 0.035" rpy="0 0 0" /> <!-- approximated only FIXME -->  
+        <mass value="0.012" />
+        <inertia  ixx="0.00000094" ixy="0.0"  ixz="0.0"  iyy="0.0000011"  iyz="0.0"
+        izz="0.00000053" />
       </inertial>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -97,7 +107,6 @@
           <!-- <mesh filename="package://sr_description/hand/model/biotacs/biotac.stl" scale="0.0254 0.0254 0.0254" /> -->
           <mesh filename="package://sr_description/hand/model/biotacs/biotac_decimated.dae" scale="0.0254 0.0254 0.0254" />
         </geometry>
-        <material name="BiotacGreen" />
       </visual>
       <collision>
         <geometry name="${prefix}${link_prefix}biotac_collision_geom">
@@ -122,7 +131,6 @@
         </plugin>
       </sensor>
       <selfCollide>true</selfCollide>
-      <material>BiotacGreen</material>
     </gazebo>
 
     <joint name="${prefix}${joint_prefix}_biotac_joint" type="fixed">
@@ -144,11 +152,6 @@
           <sphere radius="0.002" />
         </geometry>
       </visual>
-      <collision>
-        <geometry>
-          <box size="0.001 0.001 0.001" />
-        </geometry>
-      </collision>
     </link>
 
     <gazebo reference="${prefix}${link_prefix}tip">

--- a/sr_description/hand/xacro/finger/distal/distal.gazebo.xacro
+++ b/sr_description/hand/xacro/finger/distal/distal.gazebo.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="distal_gazebo" params="prefix">
+  <xacro:macro name="distal_gazebo" params="prefix link_prefix">
 
   <!-- prefix can be anything but usually is "r_" or  "l_" for right and left hands distinction -->
   <gazebo reference="${prefix}${link_prefix}distal">

--- a/sr_description/hand/xacro/finger/distal/distal.urdf.xacro
+++ b/sr_description/hand/xacro/finger/distal/distal.urdf.xacro
@@ -19,9 +19,9 @@
   <xacro:macro name="distal" params="muscle bio ubi eli prefix link_prefix joint_prefix parent">
     <link name="${prefix}${link_prefix}distal">
       <inertial>
-        <mass value="0.010" />
+        <mass value="0.012" />
         <origin xyz="0 0 0.012" />
-        <inertia  ixx="0.0000031" ixy="0.0"  ixz="0.0"  iyy="0.0000031"  iyz="0.0"
+        <inertia  ixx="0.00000094" ixy="0.0"  ixz="0.0"  iyy="0.0000011"  iyz="0.0"
         izz="0.00000053" />
       </inertial>
       <visual>
@@ -86,15 +86,19 @@
       <xacro:if value="${bio}">
 				<!-- biotac fixed distal joint -->
         <limit lower="${20/180*M_PI}" upper="${20/180*M_PI}" effort="10"
-          velocity="1.0" />
+          velocity="2.0" />
       </xacro:if> 
       <xacro:unless value="${bio}">
 				<!-- standard distal joint -->
         <limit lower="0" upper="${M_PI/2}" effort="2"
-          velocity="1.0" />
+          velocity="2.0" />
       </xacro:unless>  
-      <dynamics damping="0.001"/> 
+      <dynamics damping="0.1"/>      
     </joint>       
+    <gazebo reference="${prefix}${joint_prefix}J1">
+      <provideFeedback>1</provideFeedback>
+      <implicitSpringDamper>1</implicitSpringDamper>
+    </gazebo>          
             
     <link name="${prefix}${link_prefix}tip">
 			<inertial>
@@ -110,7 +114,7 @@
     </xacro:unless>
     <!-- extensions -->
     <!--   <xacro:distal_transmission muscletrans="${muscle}" prefix="${prefix}" /> -->
-    <xacro:distal_gazebo prefix="${prefix}" />
+    <xacro:distal_gazebo prefix="${prefix}" link_prefix="${link_prefix}"/>
   </xacro:macro>
 
 </robot>

--- a/sr_description/hand/xacro/finger/distal/distal.urdf.xacro
+++ b/sr_description/hand/xacro/finger/distal/distal.urdf.xacro
@@ -21,8 +21,8 @@
       <inertial>
         <mass value="0.010" />
         <origin xyz="0 0 0.012" />
-        <inertia  ixx="0.001" ixy="0.0"  ixz="0.0"  iyy="0.001"  iyz="0.0"
-        izz="0.00025" />
+        <inertia  ixx="0.0000031" ixy="0.0"  ixz="0.0"  iyy="0.0000031"  iyz="0.0"
+        izz="0.00000053" />
       </inertial>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -93,7 +93,7 @@
         <limit lower="0" upper="${M_PI/2}" effort="2"
           velocity="1.0" />
       </xacro:unless>  
-      <dynamics damping="0.1"/>
+      <dynamics damping="0.001"/> 
     </joint>       
             
     <link name="${prefix}${link_prefix}tip">

--- a/sr_description/hand/xacro/finger/knuckle/knuckle.gazebo.xacro
+++ b/sr_description/hand/xacro/finger/knuckle/knuckle.gazebo.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="knuckle_gazebo" params="prefix">
+  <xacro:macro name="knuckle_gazebo" params="prefix link_prefix">
 
   <!-- prefix can be anything but usually is "r_" or  "l_" for right and left hands distinction -->
   <gazebo reference="${prefix}${link_prefix}knuckle">

--- a/sr_description/hand/xacro/finger/knuckle/knuckle.urdf.xacro
+++ b/sr_description/hand/xacro/finger/knuckle/knuckle.urdf.xacro
@@ -19,8 +19,8 @@
       <inertial>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <!--<insert_block name="origin" /> -->
-        <mass value="0.08" />
-        <inertia  ixx="0.000026" ixy="0.0"  ixz="0.0"  iyy="0.000026"  iyz="0.0"	izz="0.000032" />
+        <mass value="0.008" />
+        <inertia  ixx="0.00000026" ixy="0.0"  ixz="0.0"  iyy="0.00000026"  iyz="0.0"	izz="0.00000032" />
       </inertial>
       <visual>
         <origin xyz="0 0 0.0005" rpy="0 0 0" />
@@ -44,13 +44,17 @@
       <insert_block name="origin" />
       <insert_block name="axis"/>
       <limit lower="${-20/180*M_PI}" upper="${20/180*M_PI}"
-      effort="2" velocity="1.0"/>
-      <dynamics damping="0.01"/>  
+      effort="2" velocity="2.0"/>
+      <dynamics damping="0.1"/>        
     </joint>
+    <gazebo reference="${prefix}${joint_prefix}J4">
+      <provideFeedback>1</provideFeedback>
+      <implicitSpringDamper>1</implicitSpringDamper>
+    </gazebo>
 
     <!-- extensions -->
     <xacro:knuckle_transmission muscletrans="${muscle}" prefix="${prefix}" joint_prefix="${joint_prefix}" link_prefix="${link_prefix}"/>
-    <xacro:knuckle_gazebo prefix="${prefix}" />
+    <xacro:knuckle_gazebo prefix="${prefix}" link_prefix="${link_prefix}"/>
   </xacro:macro>
 
 </robot>

--- a/sr_description/hand/xacro/finger/knuckle/knuckle.urdf.xacro
+++ b/sr_description/hand/xacro/finger/knuckle/knuckle.urdf.xacro
@@ -20,7 +20,7 @@
         <origin xyz="0 0 0" rpy="0 0 0" />
         <!--<insert_block name="origin" /> -->
         <mass value="0.08" />
-        <inertia  ixx="0.0026" ixy="0.0"  ixz="0.0"  iyy="0.0026"  iyz="0.0"	izz="0.0032" />
+        <inertia  ixx="0.000026" ixy="0.0"  ixz="0.0"  iyy="0.000026"  iyz="0.0"	izz="0.000032" />
       </inertial>
       <visual>
         <origin xyz="0 0 0.0005" rpy="0 0 0" />
@@ -45,7 +45,7 @@
       <insert_block name="axis"/>
       <limit lower="${-20/180*M_PI}" upper="${20/180*M_PI}"
       effort="2" velocity="1.0"/>
-      <dynamics damping="0.1"/>
+      <dynamics damping="0.01"/>  
     </joint>
 
     <!-- extensions -->

--- a/sr_description/hand/xacro/finger/lfmetacarpal/lfmetacarpal.gazebo.xacro
+++ b/sr_description/hand/xacro/finger/lfmetacarpal/lfmetacarpal.gazebo.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="lfmetacarpal_gazebo" params="prefix">
+  <xacro:macro name="lfmetacarpal_gazebo" params="prefix link_prefix">
 
   <!-- prefix can be anything but usually is "r_" or  "l_" for right and left hands distinction -->
   <gazebo reference="${prefix}lfmetacarpal">

--- a/sr_description/hand/xacro/finger/lfmetacarpal/lfmetacarpal.urdf.xacro
+++ b/sr_description/hand/xacro/finger/lfmetacarpal/lfmetacarpal.urdf.xacro
@@ -19,7 +19,7 @@
       <inertial>
         <origin xyz="0 0 0.04" rpy="0 0 0" />
         <mass value="0.030" />
-	    <inertia  ixx="0.0000545" ixy="0.0"  ixz="0.0"  iyy="0.000056352"  iyz="0.0" izz="0.000004272" />
+	    <inertia  ixx="0.0000145" ixy="0.0"  ixz="0.0"  iyy="0.00001638"  iyz="0.0" izz="0.000004272" />
       </inertial>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -43,13 +43,17 @@
       <origin xyz="${reflect*-0.033} 0 0.02071" rpy="0 0 0" />
       <axis xyz="0.573576436 0 ${reflect*0.819152044}" />
         <limit lower="0" upper="${45/180*M_PI}" effort="2"
-      velocity="1.0" />
-      <dynamics damping="0.001"/> 
+      velocity="2.0" />
+      <dynamics damping="0.1"/>      
     </joint>
+    <gazebo reference="${prefix}LFJ5">
+      <provideFeedback>1</provideFeedback>
+      <implicitSpringDamper>1</implicitSpringDamper>
+    </gazebo>
 
     <!-- extensions -->
     <xacro:lfmetacarpal_transmission muscletrans="${muscle}" prefix="${prefix}" />
-    <xacro:lfmetacarpal_gazebo prefix="${prefix}" />
+    <xacro:lfmetacarpal_gazebo prefix="${prefix}" link_prefix="${link_prefix}" />
 
   </xacro:macro>
 

--- a/sr_description/hand/xacro/finger/lfmetacarpal/lfmetacarpal.urdf.xacro
+++ b/sr_description/hand/xacro/finger/lfmetacarpal/lfmetacarpal.urdf.xacro
@@ -19,7 +19,7 @@
       <inertial>
         <origin xyz="0 0 0.04" rpy="0 0 0" />
         <mass value="0.030" />
-	    <inertia  ixx="0.00545" ixy="0.0"  ixz="0.0"  iyy="0.0056352"  iyz="0.0" izz="0.0004272" />
+	    <inertia  ixx="0.0000545" ixy="0.0"  ixz="0.0"  iyy="0.000056352"  iyz="0.0" izz="0.000004272" />
       </inertial>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -44,7 +44,7 @@
       <axis xyz="0.573576436 0 ${reflect*0.819152044}" />
         <limit lower="0" upper="${45/180*M_PI}" effort="2"
       velocity="1.0" />
-      <dynamics damping="0.1"/>
+      <dynamics damping="0.001"/> 
     </joint>
 
     <!-- extensions -->

--- a/sr_description/hand/xacro/finger/middle/middle.gazebo.xacro
+++ b/sr_description/hand/xacro/finger/middle/middle.gazebo.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="middle_gazebo" params="prefix">
+  <xacro:macro name="middle_gazebo" params="prefix link_prefix">
 
   <!-- prefix can be anything but usually is "r_" or  "l_" for right and left hands distinction -->
   <gazebo reference="${prefix}${link_prefix}middle">

--- a/sr_description/hand/xacro/finger/middle/middle.urdf.xacro
+++ b/sr_description/hand/xacro/finger/middle/middle.urdf.xacro
@@ -18,9 +18,9 @@
     <link name="${prefix}${link_prefix}middle">
       <inertial>
         <origin xyz="0 0 0.0125" rpy="0 0 0" />
-        <mass value="0.020" />
-        <inertia  ixx="0.0000067" ixy="0.0"  ixz="0.0"  iyy="0.0000067"  iyz="0.0"
-        izz="0.00000006" />
+        <mass value="0.017" />
+        <inertia  ixx="0.0000026" ixy="0.0"  ixz="0.0"  iyy="0.0000027"  iyz="0.0"
+        izz="0.00000087" />
       </inertial>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -55,13 +55,17 @@
       <origin xyz="0 0 0.045" rpy="0 0 0" />
       <axis xyz="1 0 0" />
       <limit lower="0" upper="${M_PI/2}" effort="2"
-      velocity="1.0" />
-      <dynamics damping="0.001"/> 
+      velocity="2.0" />
+      <dynamics damping="0.1"/>      
     </joint>
 
+   <gazebo reference="${prefix}${joint_prefix}J2">
+      <provideFeedback>1</provideFeedback>
+      <implicitSpringDamper>1</implicitSpringDamper>
+    </gazebo>
     <!-- extensions -->
     <xacro:middle_transmission muscletrans="${muscle}" prefix="${prefix}" joint_prefix="${joint_prefix}" link_prefix="${link_prefix}"/>
-    <xacro:middle_gazebo prefix="${prefix}" />
+    <xacro:middle_gazebo prefix="${prefix}" link_prefix="${link_prefix}" />
   </xacro:macro>
 
 </robot>

--- a/sr_description/hand/xacro/finger/middle/middle.urdf.xacro
+++ b/sr_description/hand/xacro/finger/middle/middle.urdf.xacro
@@ -19,8 +19,8 @@
       <inertial>
         <origin xyz="0 0 0.0125" rpy="0 0 0" />
         <mass value="0.020" />
-        <inertia  ixx="0.002" ixy="0.0"  ixz="0.0"  iyy="0.002"  iyz="0.0"
-        izz="0.0002" />
+        <inertia  ixx="0.0000067" ixy="0.0"  ixz="0.0"  iyy="0.0000067"  iyz="0.0"
+        izz="0.00000006" />
       </inertial>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -56,7 +56,7 @@
       <axis xyz="1 0 0" />
       <limit lower="0" upper="${M_PI/2}" effort="2"
       velocity="1.0" />
-      <dynamics damping="0.1"/>
+      <dynamics damping="0.001"/> 
     </joint>
 
     <!-- extensions -->

--- a/sr_description/hand/xacro/finger/proximal/proximal.gazebo.xacro
+++ b/sr_description/hand/xacro/finger/proximal/proximal.gazebo.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="proximal_gazebo" params="prefix">
+  <xacro:macro name="proximal_gazebo" params="prefix link_prefix">
 
   <!-- prefix can be anything but usually is "r_" or  "l_" for right and left hands distinction -->
   <gazebo reference="${prefix}${link_prefix}proximal">

--- a/sr_description/hand/xacro/finger/proximal/proximal.urdf.xacro
+++ b/sr_description/hand/xacro/finger/proximal/proximal.urdf.xacro
@@ -19,8 +19,8 @@
       <inertial>
         <mass value="0.030" />
         <origin xyz="0 0 0.0225" />
-        <inertia  ixx="0.000037" ixy="0.0"  ixz="0.0"  iyy="0.000037"  iyz="0.0"
-        izz="0.00000018" />
+        <inertia  ixx="0.0000098" ixy="0.0"  ixz="0.0"  iyy="0.00001"  iyz="0.0"
+        izz="0.0000018" />
       </inertial>
       <visual>
       <origin xyz="0 0 0" rpy="0 0 0" />
@@ -43,13 +43,17 @@
       <origin xyz="0 0 0" rpy="0 0 0" />
       <axis xyz="1 0 0" />
       <limit lower="0" upper="${M_PI/2}" effort="2"
-      velocity="1.0"/>
-      <dynamics damping="0.001"/> 
+      velocity="2.0"/>
+      <dynamics damping="0.1"/>      
     </joint>
+    <gazebo reference="${prefix}${joint_prefix}J3">
+      <provideFeedback>1</provideFeedback>
+      <implicitSpringDamper>1</implicitSpringDamper>
+    </gazebo>
 
     <!-- extensions -->
     <xacro:proximal_transmission muscletrans="${muscle}" prefix="${prefix}" joint_prefix="${joint_prefix}" link_prefix="${link_prefix}"/>
-    <xacro:proximal_gazebo prefix="${prefix}" />
+    <xacro:proximal_gazebo prefix="${prefix}" link_prefix="${link_prefix}"/>
   </xacro:macro>
 
 </robot>

--- a/sr_description/hand/xacro/finger/proximal/proximal.urdf.xacro
+++ b/sr_description/hand/xacro/finger/proximal/proximal.urdf.xacro
@@ -19,8 +19,8 @@
       <inertial>
         <mass value="0.030" />
         <origin xyz="0 0 0.0225" />
-        <inertia  ixx="0.003" ixy="0.0"  ixz="0.0"  iyy="0.003"  iyz="0.0"
-        izz="0.0003" />
+        <inertia  ixx="0.000037" ixy="0.0"  ixz="0.0"  iyy="0.000037"  iyz="0.0"
+        izz="0.00000018" />
       </inertial>
       <visual>
       <origin xyz="0 0 0" rpy="0 0 0" />
@@ -44,7 +44,7 @@
       <axis xyz="1 0 0" />
       <limit lower="0" upper="${M_PI/2}" effort="2"
       velocity="1.0"/>
-      <dynamics damping="0.1"/>
+      <dynamics damping="0.001"/> 
     </joint>
 
     <!-- extensions -->

--- a/sr_description/hand/xacro/forearm/forearm.urdf.xacro
+++ b/sr_description/hand/xacro/forearm/forearm.urdf.xacro
@@ -7,7 +7,7 @@
         <inertial>
         <origin xyz="0 0 0.09" rpy="0 0 0"/>
         <mass value="3.0" />
-        <inertia  ixx="0.108" ixy="0.0"  ixz="0.0"  iyy="0.108"  iyz="0.0"  izz="0.054" />
+        <inertia  ixx="0.0138" ixy="0.0"  ixz="0.0"  iyy="0.0138"  iyz="0.0"  izz="0.00744" />
         </inertial>
 
         <visual>

--- a/sr_description/hand/xacro/palm/palm.urdf.xacro
+++ b/sr_description/hand/xacro/palm/palm.urdf.xacro
@@ -18,7 +18,7 @@
       <inertial>
         <origin xyz="0 0 0.035" rpy="0 0 0" />
         <mass value="0.3" />
-        <inertia  ixx="0.0003581" ixy="0.0"  ixz="0.0"  iyy="0.0005287"  iyz="0.0"	izz="0.0002545" />
+        <inertia  ixx="0.0003581" ixy="0.0"  ixz="0.0"  iyy="0.0005287"  iyz="0.0"	izz="0.000191" />
       </inertial>
 
       <visual>
@@ -85,9 +85,14 @@
       <origin xyz="0 0 0.034" rpy="0 0 0" />
       <axis xyz="1 0 0" />
       <limit lower="${-40/180*M_PI}" upper="${28/180*M_PI}"
-      effort="30" velocity="1.0"/>
-      <dynamics damping="0.01"/>  
+      effort="30" velocity="2.0"/>
+      <dynamics damping="0.1"/>        
     </joint>
+    
+    <gazebo reference="${prefix}WRJ1">
+      <provideFeedback>1</provideFeedback>
+      <implicitSpringDamper>1</implicitSpringDamper>
+    </gazebo>
 
     <!-- extensions -->
     <xacro:shadowhand_palm_transmission muscletrans="${muscletrans}" prefix="${prefix}" />

--- a/sr_description/hand/xacro/palm/palm.urdf.xacro
+++ b/sr_description/hand/xacro/palm/palm.urdf.xacro
@@ -18,7 +18,7 @@
       <inertial>
         <origin xyz="0 0 0.035" rpy="0 0 0" />
         <mass value="0.3" />
-        <inertia  ixx="0.003581" ixy="0.0"  ixz="0.0"  iyy="0.005287"  iyz="0.0"	izz="0.002545" />
+        <inertia  ixx="0.0003581" ixy="0.0"  ixz="0.0"  iyy="0.0005287"  iyz="0.0"	izz="0.0002545" />
       </inertial>
 
       <visual>
@@ -86,7 +86,7 @@
       <axis xyz="1 0 0" />
       <limit lower="${-40/180*M_PI}" upper="${28/180*M_PI}"
       effort="30" velocity="1.0"/>
-      <dynamics damping="0.1"/>
+      <dynamics damping="0.01"/>  
     </joint>
 
     <!-- extensions -->

--- a/sr_description/hand/xacro/palm/palm_lite.urdf.xacro
+++ b/sr_description/hand/xacro/palm/palm_lite.urdf.xacro
@@ -17,7 +17,7 @@
       <inertial>
         <origin xyz="0 0 0.035" rpy="0 0 0" />
         <mass value="0.3" />
-        <inertia  ixx="0.003581" ixy="0.0"  ixz="0.0"  iyy="0.005287"  iyz="0.0"	izz="0.002545" />
+        <inertia  ixx="0.0003581" ixy="0.0"  ixz="0.0"  iyy="0.0005287"  iyz="0.0"	izz="0.000191" />
       </inertial>
 
       <visual>

--- a/sr_description/hand/xacro/thumb/thbase.urdf.xacro
+++ b/sr_description/hand/xacro/thumb/thbase.urdf.xacro
@@ -44,7 +44,7 @@
       <axis xyz="0 0 ${reflect*-1}" />
       <limit lower="${-60/180*M_PI}" upper="${60/180*M_PI}" effort="10" 
       velocity="1.0" />
-      <dynamics damping="0.1"/>
+      <dynamics damping="0.001"/> 
     </joint>
 
     <!-- extensions -->

--- a/sr_description/hand/xacro/thumb/thbase.urdf.xacro
+++ b/sr_description/hand/xacro/thumb/thbase.urdf.xacro
@@ -18,7 +18,7 @@
       <inertial>
 				<mass value="0.010" />
 				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<inertia  ixx="0.0003" ixy="0.0"  ixz="0.0"  iyy="0.0003"  iyz="0.0" izz="0.0003" />
+				<inertia  ixx="0.00000016" ixy="0.0"  ixz="0.0"  iyy="0.00000016"  iyz="0.0" izz="0.00000016" />
 			</inertial>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -42,11 +42,15 @@
       <child link="${prefix}thbase"/>
       <origin xyz="${reflect*0.034} -0.0085 0.029" rpy="0 ${M_PI/4} ${M_PI/2-reflect*M_PI/2}" />
       <axis xyz="0 0 ${reflect*-1}" />
-      <limit lower="${-60/180*M_PI}" upper="${60/180*M_PI}" effort="10" 
-      velocity="1.0" />
-      <dynamics damping="0.001"/> 
+      <limit lower="${-60/180*M_PI}" upper="${60/180*M_PI}" effort="5.0" 
+      velocity="4.0" />
+      <dynamics damping="0.2"/>       
     </joint>
 
+    <gazebo reference="${prefix}THJ5">
+      <provideFeedback>1</provideFeedback>
+      <implicitSpringDamper>1</implicitSpringDamper>
+    </gazebo>
     <!-- extensions -->
     <xacro:thbase_transmission muscletrans="${muscle}" prefix="${prefix}"/>
     <xacro:thbase_gazebo prefix="${prefix}" />

--- a/sr_description/hand/xacro/thumb/thdistal.urdf.xacro
+++ b/sr_description/hand/xacro/thumb/thdistal.urdf.xacro
@@ -34,7 +34,7 @@
 				<origin xyz="0 0 0.02" rpy="0 0 0" />
 				<axis xyz="1 0 0" />
 				<limit lower="${20*M_PI/180}" upper="${20.1*M_PI/180}" effort="10" velocity="0.1" />
-				<dynamics damping="0.1"/>
+				<dynamics damping="0.001"/> 
 			</joint>
 			
 			<link name="${prefix}thbiotac">
@@ -178,7 +178,7 @@
 				<origin xyz="0 0 0.032" rpy="0 0 ${-M_PI/2}" />
 				<axis xyz="1 0 0" />
 				<limit lower="0" upper="${90.0*M_PI/180}" effort="10" velocity="1.0" />
-				<dynamics damping="0.1"/>
+				<dynamics damping="0.001"/> 
 			</joint>
 			<link name="${prefix}thtip">
 				<inertial>

--- a/sr_description/hand/xacro/thumb/thdistal.urdf.xacro
+++ b/sr_description/hand/xacro/thumb/thdistal.urdf.xacro
@@ -21,28 +21,33 @@
 			<!--	BIOTAC -->
 			<link name="${prefix}thbiotac_J1_dummy">
 				<inertial>
-					<origin xyz="0 0 0" rpy="0 0 0" />
-					<mass value="0.01" />
-					 <inertia  ixx="0.0007" ixy="0.0"  ixz="0.0"  iyy="0.0007"  iyz="0.0"
-        izz="0.00010" />
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <mass value="0.001" />
+          <inertia  ixx="0.00000001" ixy="0.0"  ixz="0.0"  iyy="0.00000001"  iyz="0.0"
+				izz="0.00000001" />
         </inertial>
 			</link>
 			
 			<joint name="${prefix}THJ1" type="revolute">
 				<parent link="${parent}"/>
 				<child link="${prefix}thbiotac_J1_dummy"/>
-				<origin xyz="0 0 0.02" rpy="0 0 0" />
+				<origin xyz="0 0 0.02" rpy="0 0 ${-M_PI/2}" />
 				<axis xyz="1 0 0" />
-				<limit lower="${20*M_PI/180}" upper="${20.1*M_PI/180}" effort="10" velocity="0.1" />
-				<dynamics damping="0.001"/> 
+				<limit lower="${20*M_PI/180}" upper="${20.1*M_PI/180}" effort="0.0" velocity="2.0" />
+				<dynamics damping="0.5"/>
 			</joint>
+      
+			<gazebo reference="${prefix}THJ1">
+				<provideFeedback>1</provideFeedback>
+				<implicitSpringDamper>1</implicitSpringDamper>
+			</gazebo>
 			
 			<link name="${prefix}thbiotac">
 				<inertial>
-					<origin xyz="0 0 0" rpy="0 0 0" />
-					<mass value="0.2" />
-					 <inertia  ixx="0.0007" ixy="0.0"  ixz="0.0"  iyy="0.0007"  iyz="0.0"
-        izz="0.00010" />
+          <origin xyz="-0.009 0.0 0.035" rpy="0 0 ${-M_PI/2}" /> <!-- approximated only FIXME -->
+					<mass value="0.008" />
+					 <inertia  ixx="0.0000011" ixy="0.0"  ixz="0.0"  iyy="0.0000011"  iyz="0.0"
+        izz="0.0000005" />
 				</inertial>
 				<visual>
 					<origin xyz="0 0 0" rpy="0 0 0" />
@@ -83,8 +88,9 @@
 			<joint name="${prefix}th_biotac_joint" type="fixed">
 				<parent link="${prefix}thmiddle"/>
 				<child link="${prefix}thbiotac"/>
-				<origin xyz="0 0.0 0.01" rpy="0 0 -1.571" />
+				<origin xyz="0 0.0 0.01" rpy="0 0 ${-M_PI/2}" />
 			</joint>
+    
 				
 			
 		  <!-- extra link to imaginary sphere in fingertip for FK/IK calculations -->
@@ -100,11 +106,6 @@
 						<sphere radius="0.002" />
 					</geometry>
 				</visual>
-				<collision>
-					<geometry>
-						<box size="0.001 0.001 0.001" />
-					</geometry>
-				</collision>
 			</link>
 
 			<gazebo reference="${prefix}thtip">
@@ -124,8 +125,8 @@
 				<inertial>
 					<mass value="0.016" />
 					<origin xyz="0 0 0.01375" rpy="0 0 0"/>
-					 <inertia  ixx="0.0007" ixy="0.0"  ixz="0.0"  iyy="0.0007"  iyz="0.0"
-        izz="0.00010" />
+					 <inertia  ixx="0.0000021" ixy="0.0"  ixz="0.0"  iyy="0.0000022"  iyz="0.0"
+        izz="0.000001" />
 				</inertial>
 				<visual>
 					<origin xyz="0 0 0" rpy="0 0 0" />
@@ -177,9 +178,14 @@
 				<child link="${prefix}thdistal"/>
 				<origin xyz="0 0 0.032" rpy="0 0 ${-M_PI/2}" />
 				<axis xyz="1 0 0" />
-				<limit lower="0" upper="${90.0*M_PI/180}" effort="10" velocity="1.0" />
-				<dynamics damping="0.001"/> 
+				<limit lower="0" upper="${90.0*M_PI/180}" effort="1.0" velocity="4.0" />
+				<dynamics damping="0.2"/>      
 			</joint>
+			<gazebo reference="${prefix}THJ1">
+				<provideFeedback>1</provideFeedback>
+				<implicitSpringDamper>1</implicitSpringDamper>
+			</gazebo>
+      
 			<link name="${prefix}thtip">
 				<inertial>
 					<mass value="0.001" />

--- a/sr_description/hand/xacro/thumb/thhub.urdf.xacro
+++ b/sr_description/hand/xacro/thumb/thhub.urdf.xacro
@@ -55,7 +55,7 @@
         <axis xyz="1 0 0" />
         <limit lower="${-12/180*M_PI}" upper="${12/180*M_PI}" effort="10"
         velocity="1.0" />
-        <dynamics damping="0.1"/>
+        <dynamics damping="0.02"/>    
       </joint>
     </xacro:unless>
 

--- a/sr_description/hand/xacro/thumb/thhub.urdf.xacro
+++ b/sr_description/hand/xacro/thumb/thhub.urdf.xacro
@@ -17,10 +17,10 @@
   <xacro:macro name="thhub" params="muscle prefix parent is_lite">
     <link name="${prefix}thhub">
       <inertial>
-				<mass value="0.01" />
+				<mass value="0.005" />
 				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<inertia  ixx="0.0003" ixy="0.0"  ixz="0.0"  iyy="0.0003"  iyz="0.0"
-				izz="0.0003" />
+				<inertia  ixx="0.0000001" ixy="0.0"  ixz="0.0"  iyy="0.0000001"  iyz="0.0"
+				izz="0.0000001" />
       </inertial>
       <visual>
 				<origin xyz="0 0 0" rpy="0 0 0" />
@@ -53,10 +53,16 @@
         <child link="${prefix}thhub"/>
         <origin xyz="0 0 0.038" rpy="0 0 0" />
         <axis xyz="1 0 0" />
-        <limit lower="${-12/180*M_PI}" upper="${12/180*M_PI}" effort="10"
-        velocity="1.0" />
-        <dynamics damping="0.02"/>    
+        <limit lower="${-12/180*M_PI}" upper="${12/180*M_PI}" effort="2.0"
+        velocity="4.0" />
+        <dynamics damping="0.2"/>           
       </joint>
+      <gazebo reference="${prefix}THJ3">
+        <provideFeedback>1</provideFeedback>
+        <implicitSpringDamper>1</implicitSpringDamper>
+      </gazebo>
+      
+      
     </xacro:unless>
 
 		<!-- extensions -->

--- a/sr_description/hand/xacro/thumb/thmiddle.urdf.xacro
+++ b/sr_description/hand/xacro/thumb/thmiddle.urdf.xacro
@@ -71,7 +71,7 @@
       <axis xyz="0 -1 0" />
       <limit lower="${-40/180*M_PI}" upper="${40/180*M_PI}" effort="10"
       velocity="1.0" />
-      <dynamics damping="0.1"/>
+      <dynamics damping="0.001"/> 
     </joint>
 
 		<!-- extensions -->

--- a/sr_description/hand/xacro/thumb/thmiddle.urdf.xacro
+++ b/sr_description/hand/xacro/thumb/thmiddle.urdf.xacro
@@ -16,9 +16,9 @@
   <xacro:macro name="thmiddle" params="muscle bio prefix parent">
     <link name="${prefix}thmiddle">
       <inertial>
-        <mass value="0.027" />
+        <mass value="0.020" />
         <origin xyz="0 0 0.016" rpy="0 0 0"/>
-          <inertia  ixx="0.0026" ixy="0.0"  ixz="0.0"  iyy="0.0026"  iyz="0.0" izz="0.000169" />
+          <inertia  ixx="0.0000051" ixy="0.0"  ixz="0.0"  iyy="0.0000051"  iyz="0.0" izz="0.00000121" />
       </inertial>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -26,7 +26,6 @@
         <geometry name="${prefix}thmiddle_visual">
           <mesh filename="package://sr_description/hand/model/biotacs/biotac_thumb_adapter.dae" scale="0.001 0.001 0.001" />
         </geometry>
-        <material name="BiotacGreen" />
         </xacro:if>
         <xacro:unless value="${bio}">
         <geometry name="${prefix}thmiddle_visual">
@@ -38,15 +37,18 @@
         </xacro:unless> 
       </visual>  
       <collision>
-        <origin xyz="0 0 0.012" rpy="0 0 0 " />
-        <geometry name="${prefix}thmiddle_collision_geom">
-          <xacro:if value="${bio}">
-            <box size="0.008 0.008 0.01" />
-          </xacro:if>
-          <xacro:unless value="${bio}">
+        <xacro:if value="${bio}">
+          <origin xyz="0 0 0.005" rpy="0 0 0 " />
+          <geometry name="${prefix}thmiddle_collision_geom">
+            <box size="0.001 0.001 0.001" />
+          </geometry>
+        </xacro:if>
+        <xacro:unless value="${bio}">
+          <origin xyz="0 0 0.012" rpy="0 0 0 " />
+          <geometry name="${prefix}thmiddle_collision_geom">
             <cylinder radius="0.011" length="0.018" />
-          </xacro:unless> 
-        </geometry>
+          </geometry>
+        </xacro:unless> 
       </collision>
       <xacro:unless value="${bio}">
      <collision>
@@ -69,11 +71,15 @@
 					<origin xyz="0 0 0" rpy="0 0 0" />
 				</xacro:unless> 
       <axis xyz="0 -1 0" />
-      <limit lower="${-40/180*M_PI}" upper="${40/180*M_PI}" effort="10"
-      velocity="1.0" />
-      <dynamics damping="0.001"/> 
+      <limit lower="${-40/180*M_PI}" upper="${40/180*M_PI}" effort="2.0"
+      velocity="2.0" />
+      <dynamics damping="0.1"/>      
     </joint>
 
+    <gazebo reference="${prefix}THJ2">
+      <provideFeedback>1</provideFeedback>
+      <implicitSpringDamper>1</implicitSpringDamper>
+    </gazebo>
 		<!-- extensions -->
 		<xacro:thmiddle_transmission muscletrans="${muscle}" prefix="${prefix}"/>
 		<xacro:thmiddle_gazebo prefix="${prefix}" />

--- a/sr_description/hand/xacro/thumb/thproximal.urdf.xacro
+++ b/sr_description/hand/xacro/thumb/thproximal.urdf.xacro
@@ -45,7 +45,7 @@
       <axis xyz="${reflect} 0 0" />
       <limit lower="0" upper="${70/180*M_PI}" effort="10"
       velocity="1.0" />
-      <dynamics damping="0.1"/>
+      <dynamics damping="0.005"/>  
     </joint>
 
     <!-- extensions -->

--- a/sr_description/hand/xacro/thumb/thproximal.urdf.xacro
+++ b/sr_description/hand/xacro/thumb/thproximal.urdf.xacro
@@ -18,8 +18,8 @@
       <inertial>
 				<mass value="0.040" />
 				<origin xyz="0 0 0.019" rpy="0 0 0"/>
-					<inertia  ixx="0.00496" ixy="0.0"  ixz="0.0"  iyy="0.00496"  iyz="0.0"
-				izz="0.000312" />
+					<inertia  ixx="0.0000136" ixy="0.0"  ixz="0.0"  iyy="0.0000136"  iyz="0.0"
+				izz="0.00000313" />
 			</inertial>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -43,10 +43,15 @@
       <child link="${prefix}thproximal"/>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <axis xyz="${reflect} 0 0" />
-      <limit lower="0" upper="${70/180*M_PI}" effort="10"
-      velocity="1.0" />
-      <dynamics damping="0.005"/>  
+      <limit lower="0.0" upper="${70/180*M_PI}" effort="3"
+      velocity="4.0" />
+      <dynamics damping="0.2"/>         
     </joint>
+    
+    <gazebo reference="${prefix}THJ4">
+      <provideFeedback>1</provideFeedback>
+      <implicitSpringDamper>1</implicitSpringDamper>
+    </gazebo>
 
     <!-- extensions -->
     <xacro:thproximal_transmission muscletrans="${muscle}" prefix="${prefix}"/>

--- a/sr_description/hand/xacro/wrist/wrist.urdf.xacro
+++ b/sr_description/hand/xacro/wrist/wrist.urdf.xacro
@@ -9,9 +9,9 @@
   <xacro:macro name="wrist" params="muscletrans prefix reflect parent *origin">  
     <link name="${prefix}wrist" >
       <inertial>
-		  <origin xyz="0 0 0" rpy="0 0 0" />
+		  <origin xyz="0 0 0.029" rpy="0 0 0" />
 		  <mass value="0.1" />
-		  <inertia  ixx="0.000024" ixy="0.0"  ixz="0.0"  iyy="0.000104"  iyz="0.0" izz="0.0000867" />
+		  <inertia  ixx="0.000035" ixy="0.0"  ixz="0.0"  iyy="0.000064"  iyz="0.0" izz="0.0000438" />
       </inertial>
       <visual>
 		  <origin xyz="0 0 0" rpy="0 0 0" />
@@ -64,9 +64,14 @@
       <child link="${prefix}wrist"/>
       <insert_block name="origin" />
       <axis xyz="0 ${reflect} 0" />
-      <limit lower="${-30/180*M_PI}" upper="${10/180*M_PI}" effort="30" velocity="1.0"/>
-      <dynamics damping="0.01"/>  
+      <limit lower="${-30/180*M_PI}" upper="${10/180*M_PI}" effort="10" velocity="2.0"/>
+      <dynamics damping="0.1"/>        
     </joint>
+    
+    <gazebo reference="${prefix}WRJ2">
+      <provideFeedback>1</provideFeedback>
+      <implicitSpringDamper>1</implicitSpringDamper>
+    </gazebo>
     
     <!-- extensions -->
     <xacro:shadowhand_wrist_transmission muscletrans="${muscletrans}" prefix="${prefix}" />

--- a/sr_description/hand/xacro/wrist/wrist.urdf.xacro
+++ b/sr_description/hand/xacro/wrist/wrist.urdf.xacro
@@ -11,9 +11,8 @@
       <inertial>
 		  <origin xyz="0 0 0" rpy="0 0 0" />
 		  <mass value="0.1" />
-		  <inertia  ixx="0.0120" ixy="0.0"  ixz="0.0"  iyy="0.0148"  iyz="0.0" izz="0.00438" />
+		  <inertia  ixx="0.000024" ixy="0.0"  ixz="0.0"  iyy="0.000104"  iyz="0.0" izz="0.0000867" />
       </inertial>
-
       <visual>
 		  <origin xyz="0 0 0" rpy="0 0 0" />
 		  <geometry name="${prefix}wrist_visual">
@@ -66,7 +65,7 @@
       <insert_block name="origin" />
       <axis xyz="0 ${reflect} 0" />
       <limit lower="${-30/180*M_PI}" upper="${10/180*M_PI}" effort="30" velocity="1.0"/>
-      <dynamics damping="0.1"/>
+      <dynamics damping="0.01"/>  
     </joint>
     
     <!-- extensions -->

--- a/sr_description/other/worlds/shadowhand.world
+++ b/sr_description/other/worlds/shadowhand.world
@@ -7,5 +7,25 @@
     <include>
       <uri>model://sun</uri>
     </include>
+      <physics type="ode">
+      <gravity>0.000000 0.000000 -9.810000</gravity>
+      <ode>
+        <solver>
+          <type>quick</type>
+          <iters>100</iters>
+          <precon_iters>0</precon_iters>
+          <sor>1.000000</sor>
+        </solver>
+        <constraints>
+          <cfm>0.000000</cfm>
+          <erp>0.200000</erp>
+          <contact_max_correcting_vel>0.000000</contact_max_correcting_vel>
+          <contact_surface_layer>0.00000</contact_surface_layer>
+        </constraints>
+      </ode>
+      <real_time_update_rate>0.000000</real_time_update_rate>
+      <max_step_size>0.001000</max_step_size>
+    </physics>
+    
   </world>
 </sdf>

--- a/sr_gazebo_plugins/src/gazebo_ros_controller_manager.cpp
+++ b/sr_gazebo_plugins/src/gazebo_ros_controller_manager.cpp
@@ -205,7 +205,6 @@ void GazeboRosControllerManager::UpdateChild()
   common::Time gz_time_now = parent_model_->GetWorld()->GetSimTime();
   ros::Time sim_time_ros(gz_time_now.sec, gz_time_now.nsec);
   ros::Duration sim_period = sim_time_ros - last_update_sim_time_ros_;
-
   if (getenv("CHECK_SPEEDUP"))
   {
     double wall_elapsed = world->GetRealTime().Double() - wall_start_;
@@ -278,10 +277,18 @@ void GazeboRosControllerManager::UpdateChild()
     double damping_coef = 0;
     if (fst->joint_->dynamics)
       damping_coef = fst->joint_->dynamics->damping;
-
+    
     double current_velocity = joints_[i]->GetVelocity(0);
-    double damping_force = damping_coef * current_velocity;
-    double effort_command = effort - damping_force;
+    // using implicit spring damper from gazebo instead of explicit.
+    //double damping_force = damping_coef * current_velocity;
+    //double effort_command = effort - damping_force;
+    double effort_command = effort;
+    //enforce limits (are these limites enforced in gazebo ?)
+    //if (fst->joint_->limits)
+    //{
+      //double effort_limit= fst->joint_->limits->effort;
+      //effort_command=std::min(std::max(effort_command, -effort_limit), effort_limit);
+    //}
     joints_[i]->SetForce(0, effort_command);
   }
   last_write_sim_time_ros_ = sim_time_ros;


### PR DESCRIPTION
Following this https://github.com/shadow-robot/sr-ros-interface/issues/196 request of merging realistic inertia by @hsu, and thanks to his advice, new inertia were set and the root problem of exploding hand was found : explicit viscous damping does not work on small elements with very small inertia. Implicit viscous damping is now used and damping coefficient was retuned. New ode parameters and a complete retuning of the hand was also necessary.  Biotac hand was also adapted, tested and is stable. Hand lite works too.

Arm was tuned with hand attached. It reacts a bit abruptly when no hand attached but this cannot be avoided unless two different controller settings are loaded.
mixed_position_velocity tuning is now broken but is probably not used. I will work on that later as it is either really hard to tune or impossible (velocity measurements are very noisy, hence implicit viscous damping, which breaks velocity controller)

See https://github.com/shadow-robot/sr-ros-interface/issues/196 for another remaining minor problem
Doc about inertia computation added.
