### PR TITLE
Fixed thhub inertia (fixes strong THJ2 movement when THJ5 moves)

### DIFF
--- a/sr_description/hand/xacro/thumb/thhub.urdf.xacro
+++ b/sr_description/hand/xacro/thumb/thhub.urdf.xacro
@@ -19,8 +19,8 @@
       <inertial>
 				<mass value="0.005" />
 				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<inertia  ixx="0.0000001" ixy="0.0"  ixz="0.0"  iyy="0.0000001"  iyz="0.0"
-				izz="0.0000001" />
+				<inertia  ixx="0.000001" ixy="0.0"  ixz="0.0"  iyy="0.000001"  iyz="0.0"
+				izz="0.0000003" />
       </inertial>
       <visual>
 				<origin xyz="0 0 0" rpy="0 0 0" />


### PR DESCRIPTION
Inertia in the thhub was an order of magnitude smaller than the parent and child links. It created a very loose link in the middle, generating the last problem mentioned in https://github.com/shadow-robot/sr-ros-interface/issues/196
This fix makes the hand behave better
