### PR TITLE
Fixes #201 - deprecated traj ctrl

### DIFF
--- a/sr_description/CMakeLists.txt
+++ b/sr_description/CMakeLists.txt
@@ -5,7 +5,7 @@ include_directories(${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
 
 catkin_package(
     DEPENDS
-    CATKIN_DEPENDS urdf xacro
+    CATKIN_DEPENDS urdf xacro position_controllers robot_mechanism_controllers
     INCLUDE_DIRS
     LIBRARIES
 )

--- a/sr_description/arm/config/arm_controller.yaml
+++ b/sr_description/arm/config/arm_controller.yaml
@@ -34,23 +34,8 @@ sa_er_position_controller:
     d: 5.0
     i_clamp: 5.0
 
-r_arm_cartesian_pose_controller:
-  type: robot_mechanism_controllers/CartesianPoseController
-  root_name: shadowarm_base
-  tip_name: palm
-  fb_trans:
-    p: 20.0
-    i: 0.5
-    d: 0.0
-    i_clamp: 1.0
-  fb_rot:
-    p: 0.5
-    i: 0.1
-    d: 0.0
-    i_clamp: 0.2
-
 r_arm_joint_trajectory_controller:
-  type: robot_mechanism_controllers/JointSplineTrajectoryController
+  type: position_controllers/JointTrajectoryController
   joints:
     - ShoulderJRotate
     - ShoulderJSwing

--- a/sr_description/arm/config/arm_controller.yaml
+++ b/sr_description/arm/config/arm_controller.yaml
@@ -35,18 +35,14 @@ sa_er_position_controller:
     i_clamp: 5.0
 
 r_arm_joint_trajectory_controller:
-  type: position_controllers/JointTrajectoryController
+  type: effort_controllers/JointTrajectoryController
   joints:
     - ShoulderJRotate
     - ShoulderJSwing
     - ElbowJSwing
     - ElbowJRotate
-    - WRJ2
-    - WRJ1
   gains:
     ShoulderJRotate: {p: 140.0, d: 30.0}
     ShoulderJSwing: {p: 140.0, d: 30.0}
     ElbowJSwing: {p: 140.0, d: 30.0}
     ElbowJRotate: {p: 140.0, d: 30.0}
-    WRJ2: {p: 140.0, d: 30.0}
-    WRJ1: {p: 140.0, d: 30.0}

--- a/sr_description/package.xml
+++ b/sr_description/package.xml
@@ -22,6 +22,8 @@
   <!-- Dependencies needed after this package is compiled. -->
   <run_depend>urdf</run_depend>
   <run_depend>xacro</run_depend>
+  <run_depend>position_controllers</run_depend>
+  <run_depend>robot_mechanism_controllers</run_depend>
 
   <!-- Dependencies needed only for running tests. -->
   <test_depend>gtest</test_depend>

--- a/sr_hand/launch/gazebo/gazebo_arm_and_hand.launch
+++ b/sr_hand/launch/gazebo/gazebo_arm_and_hand.launch
@@ -43,7 +43,7 @@
   <!-- Controllers for the hand -->
   <include file="$(find sr_hand)/launch/gazebo/loaders/hand_controllers.launch"/>
 
-  <!-- launch trajectory controllers for the hand -->
+  <!-- launch trajectory controllers for the arm -->
   <include file="$(find sr_hand)/launch/gazebo/loaders/arm_controllers_extended.launch"/>
 
   <include file="$(find ros_ethercat_model)/launch/joint_state_publisher.launch"/>

--- a/sr_hand/launch/gazebo/gazebo_arm_and_hand.launch
+++ b/sr_hand/launch/gazebo/gazebo_arm_and_hand.launch
@@ -40,15 +40,14 @@
   </group>
   <node name="spawn_hand" pkg="gazebo_ros" type="spawn_model" args="-urdf -param robot_description -z 0.0 -model shadow_model -J ShoulderJSwing 0.78 -J ElbowJSwing 2.0" respawn="false" output="screen" />
 
-  <!-- Controllers for the arm and hand -->
+  <!-- Controllers for the hand -->
   <include file="$(find sr_hand)/launch/gazebo/loaders/hand_controllers.launch"/>
-  <include file="$(find sr_hand)/launch/gazebo/loaders/arm_controllers.launch"/>
 
-  <!-- launch more exotic controllers (trajectory, cartesian, etc...) -->
+  <!-- launch trajectory controllers for the hand -->
   <include file="$(find sr_hand)/launch/gazebo/loaders/arm_controllers_extended.launch"/>
 
   <include file="$(find ros_ethercat_model)/launch/joint_state_publisher.launch"/>
-  
+
   <node pkg="robot_state_publisher" type="state_publisher"
         name="robot_state_publisher_full_pos">
     <param name="publish_frequency" type="double" value="20.0" />

--- a/sr_hand/launch/gazebo/loaders/arm_controllers_extended.launch
+++ b/sr_hand/launch/gazebo/loaders/arm_controllers_extended.launch
@@ -4,6 +4,6 @@
 
   <node name="spawn_gazebo_arm_controllers_extended"
 	pkg="controller_manager" type="spawner" respawn="false" output="screen"
-	args="--shutdown-timeout=1.0 r_arm_cartesian_pose_controller r_arm_joint_trajectory_controller"/>
+	args="--shutdown-timeout=1.0 r_arm_joint_trajectory_controller"/>
 
 </launch>


### PR DESCRIPTION
Can't run joint position control + trajectory controllers at the same time anymore. I decided to use trajectory controllers (on the arm) by default when running the arm and hand together as it is more standard. Let me know what you think.
