### PR TITLE
dae should use Y_UP for clean collision in ompl

### DIFF
--- a/sr_description/hand/model/biotacs/sp.dae
+++ b/sr_description/hand/model/biotacs/sp.dae
@@ -8,7 +8,7 @@
     <created>2015-06-02T09:41:10</created>
     <modified>2015-06-02T09:41:10</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
+    <up_axis>Y_UP</up_axis>
   </asset>
   <library_cameras>
     <camera id="Camera-camera" name="Camera">


### PR DESCRIPTION
From @guihomework:

Be careful, if you use
the new file for collision too, OMPL might have issues (similar to #144)

DAE collision model should have the option 'up_axis Y_UP' because OMPL
reads this tag when rviz/gazebo do not (so mode render correctly).
Blender uses by default Z_UP in DAE exports which turns the colliding
model 90 degree in OMPL and collides with the environment while planning
although the display in RVIZ is OK
