### PR TITLE
Allow prefixes in actuator names

### DIFF
--- a/sr_mechanism_controllers/src/srh_fake_joint_calibration_controller.cpp
+++ b/sr_mechanism_controllers/src/srh_fake_joint_calibration_controller.cpp
@@ -140,7 +140,9 @@ namespace controller {
   void SrhFakeJointCalibrationController::initialize_pids()
   {
     ///Reset the motor to make sure we have the proper 0 + correct PID settings
-    string service_name = "realtime_loop/" + ns_ + "reset_motor_" + boost::to_upper_copy(actuator_name_);
+    // trim any prefix in the actuator_name for low level driver to find it
+    std::string lowlevel_actuator_name= actuator_name_.substr(actuator_name_.size()-4,4);
+    string service_name = "realtime_loop/" + ns_ + "reset_motor_" + boost::to_upper_copy(lowlevel_actuator_name);
     if( ros::service::waitForService (service_name, ros::Duration(2.0)) )
     {
       std_srvs::Empty srv;


### PR DESCRIPTION
This simple update permits to handle prefixed joints. The prefix will be trimmed by taking only the 4 last characters of the actuator name. Should not affect existing setups not having prefixes.
- Short motivation:
  This change helps when the fake calibration yaml already contains joint and actuator names with prefixes.
- Detailed motivation:
  Indeed, in the case of the driver being started in a namespace (realtime loop in a namespace), BUT with hand_mapping set to empty (to avoid double /rh/rh/tactile), the prefix of the joints can then directly be given to calibration ctrl via the calibration yaml. Due to the low-level driver services requesting a name without prefix ( https://github.com/shadow-robot/sr-ros-interface-ethercat/issues/56 ), it needs to be trimmed off.
